### PR TITLE
feat: build shared client validation utilities

### DIFF
--- a/utils/validation.js
+++ b/utils/validation.js
@@ -9,6 +9,10 @@ export const VALIDATION_LIMITS = Object.freeze({
   passwordMinLength: 8,
   passwordMaxLength: 128,
   nameMaxLength: 50,
+  ratingMin: 1,
+  ratingMax: 5,
+  noteMaxLength: 1000,
+  reviewTextMaxLength: 2000,
   textMaxLength: 5000
 });
 
@@ -26,7 +30,13 @@ export const VALIDATION_HINTS = Object.freeze({
     'Include at least one special character.',
     'Spaces are not allowed.'
   ]),
-  confirmPassword: Object.freeze(['Must match the password exactly.'])
+  confirmPassword: Object.freeze(['Must match the password exactly.']),
+  rating: Object.freeze([
+    `Choose a rating from ${VALIDATION_LIMITS.ratingMin} to ${VALIDATION_LIMITS.ratingMax}.`
+  ]),
+  note: Object.freeze([
+    `Use ${VALIDATION_LIMITS.noteMaxLength} characters or fewer.`
+  ])
 });
 
 export class ValidationError extends Error {
@@ -337,6 +347,82 @@ export function validatePasswordConfirmation(
   return normalizedConfirmation;
 }
 
+export function validateRating(
+  value,
+  {
+    field = 'rating',
+    label,
+    min = VALIDATION_LIMITS.ratingMin,
+    max = VALIDATION_LIMITS.ratingMax
+  } = {}
+) {
+  const resolvedLabel = getFieldLabel(field, label);
+  const normalized = normalizeTextInput(value);
+
+  if (normalized.length === 0) {
+    throw makeValidationError(`${resolvedLabel} is required.`, {
+      field,
+      label: resolvedLabel,
+      code: 'required',
+      value: normalized
+    });
+  }
+
+  const rating = Number(normalized);
+
+  if (!Number.isInteger(rating)) {
+    throw makeValidationError(`${resolvedLabel} must be a whole number.`, {
+      field,
+      label: resolvedLabel,
+      code: 'invalid_number',
+      value: normalized
+    });
+  }
+
+  if (rating < min || rating > max) {
+    throw makeValidationError(`${resolvedLabel} must be between ${min} and ${max}.`, {
+      field,
+      label: resolvedLabel,
+      code: 'out_of_range',
+      value: normalized
+    });
+  }
+
+  return rating;
+}
+
+export function validateNoteLength(
+  value,
+  {
+    field = 'note',
+    label,
+    maxLength = VALIDATION_LIMITS.noteMaxLength,
+    emptyValue = ''
+  } = {}
+) {
+  return validateOptionalString(value, {
+    field,
+    label,
+    maxLength,
+    emptyValue
+  });
+}
+
+export function validateReviewText(
+  value,
+  {
+    field = 'reviewText',
+    label = 'Review',
+    maxLength = VALIDATION_LIMITS.reviewTextMaxLength
+  } = {}
+) {
+  return validateRequiredString(value, {
+    field,
+    label,
+    maxLength
+  });
+}
+
 export function composeValidators(...validators) {
   return (value, context) => validators.reduce((currentValue, validator) => validator(currentValue, context), value);
 }
@@ -591,4 +677,13 @@ export const profileValidationSchema = Object.freeze({
   lastName: (value) => validateName(value, { field: 'lastName', label: 'Last name' }),
   email: (value) => validateEmail(value, { field: 'email', label: 'Email' }),
   username: (value) => validateUsername(value, { field: 'username', label: 'Username' })
+});
+
+export const reviewValidationSchema = Object.freeze({
+  reviewText: (value) => validateReviewText(value, { field: 'reviewText', label: 'Review' }),
+  rating: (value) => validateRating(value, { field: 'rating', label: 'Rating' })
+});
+
+export const shortlistNoteValidationSchema = Object.freeze({
+  privateNote: (value) => validateNoteLength(value, { field: 'privateNote', label: 'Private note' })
 });

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -368,9 +368,7 @@ export function validateRating(
     });
   }
 
-  const rating = Number(normalized);
-
-  if (!Number.isInteger(rating)) {
+  if (!/^-?\d+$/.test(normalized)) {
     throw makeValidationError(`${resolvedLabel} must be a whole number.`, {
       field,
       label: resolvedLabel,
@@ -378,6 +376,8 @@ export function validateRating(
       value: normalized
     });
   }
+
+  const rating = Number(normalized);
 
   if (rating < min || rating > max) {
     throw makeValidationError(`${resolvedLabel} must be between ${min} and ${max}.`, {


### PR DESCRIPTION
## Summary

This PR extends the shared front-end validation utilities so common form fields can reuse one consistent client-side validation layer.

### What changed

- Added reusable rating validation with shared min/max limits.
- Added reusable note-length validation for optional note fields.
- Added reusable review-text validation for required review content.
- Added shared validation limits for:
  - rating range
  - private note length
  - review text length
- Added validation hints for rating and note fields.
- Added reusable schemas for:
  - review forms
  - shortlist note forms
- Kept the existing shared validation utilities for required text, email, username, password, names, form validation, error summaries, and field accessibility state.

## Behavior impact

- Rating fields can now be validated as whole numbers within the allowed range.
- Private notes can now be validated as optional text with a maximum length.
- Review text can now be validated as required bounded text.
- Future review and shortlist forms can reuse shared schemas instead of duplicating validation logic.
- Existing auth/profile validation helpers remain unchanged.

## Files Changed

- `utils/validation.js`

## Testing

Verified the following:

- Validation module imports successfully.
- Required text validation accepts trimmed text and rejects empty input.
- Email validation normalizes valid emails and rejects invalid emails.
- Username validation accepts valid usernames and rejects invalid usernames.
- Password validation accepts strong passwords and rejects weak passwords.
- Rating validation:
  - accepts integer values from `1` to `5`
  - parses valid string input
  - rejects empty, decimal, and out-of-range values
- Note validation:
  - trims valid notes
  - allows empty optional notes
  - rejects notes over the maximum length
- Review text validation:
  - trims valid review text
  - rejects empty review text
- `validateForm` works with the new review validation schema.
- `validateForm` works with the new shortlist note validation schema.
- `git diff --check` passes.
- Front-end app starts successfully after installing dependencies.
- `GET /` returns `200 OK`.

## Notes

- Temporary local frontend server was stopped after verification.
- `package.json` and `package-lock.json` were not changed.
- This PR only changes `utils/validation.js`.