### PR TITLE
feat: add ajax form helper

### DIFF
--- a/public/js/ajax-form.js
+++ b/public/js/ajax-form.js
@@ -257,9 +257,9 @@
         success: false,
         status: 0,
         data: null,
-        error: error.message || DEFAULT_ERROR_MESSAGE,
+        error: DEFAULT_ERROR_MESSAGE,
         fieldErrors: null,
-        message: error.message || DEFAULT_ERROR_MESSAGE,
+        message: DEFAULT_ERROR_MESSAGE,
         response: null,
         payload: null
       };
@@ -292,6 +292,8 @@
     return Array.from(document.querySelectorAll(selector)).map((form) => attachAjaxForm(form, options));
   }
 
+  let _autoCleanups = [];
+
   window.LeaseWiseAjaxForms = Object.freeze({
     attachAjaxForm,
     attachAjaxForms,
@@ -301,12 +303,15 @@
     renderFieldErrors,
     serializeForm,
     setFormLoading,
-    submitAjaxForm
+    submitAjaxForm,
+    detachAll: () => { _autoCleanups.forEach((fn) => fn()); _autoCleanups = []; }
   });
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => attachAjaxForms(), { once: true });
+    document.addEventListener('DOMContentLoaded', () => {
+      _autoCleanups = attachAjaxForms();
+    }, { once: true });
   } else {
-    attachAjaxForms();
+    _autoCleanups = attachAjaxForms();
   }
 })();

--- a/public/js/ajax-form.js
+++ b/public/js/ajax-form.js
@@ -1,0 +1,312 @@
+(() => {
+  const DEFAULT_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+  const DEFAULT_SUCCESS_MESSAGE = 'Saved successfully.';
+  const DEFAULT_LOADING_TEXT = 'Saving...';
+  const JSON_CONTENT_TYPE = 'application/json';
+
+  function isForm(value) {
+    return value && value.tagName === 'FORM';
+  }
+
+  function getSubmitButtons(form) {
+    return Array.from(form.querySelectorAll('button:not([type]), button[type="submit"], input[type="submit"]'));
+  }
+
+  function getMessageTarget(form, dataKey, fallbackSelector) {
+    const selector = form.dataset[dataKey];
+
+    if (selector) {
+      return form.querySelector(selector) || document.querySelector(selector);
+    }
+
+    return form.querySelector(fallbackSelector);
+  }
+
+  function writeMessage(element, message) {
+    if (!element) {
+      return;
+    }
+
+    element.textContent = message || '';
+    element.hidden = !message;
+  }
+
+  function announce(form, message) {
+    const statusElement = (form.ownerDocument || document).getElementById('global-status');
+
+    if (statusElement) {
+      statusElement.textContent = message || '';
+    }
+  }
+
+  function setButtonLoading(button, isLoading, loadingText) {
+    if (!button.dataset.ajaxOriginalDisabled) {
+      button.dataset.ajaxOriginalDisabled = button.disabled ? 'true' : 'false';
+    }
+
+    if (button.tagName === 'INPUT') {
+      if (!button.dataset.ajaxOriginalValue) {
+        button.dataset.ajaxOriginalValue = button.value;
+      }
+
+      button.value = isLoading ? loadingText : button.dataset.ajaxOriginalValue;
+    } else {
+      if (!button.dataset.ajaxOriginalText) {
+        button.dataset.ajaxOriginalText = button.textContent;
+      }
+
+      button.textContent = isLoading ? loadingText : button.dataset.ajaxOriginalText;
+    }
+
+    button.disabled = isLoading || button.dataset.ajaxOriginalDisabled === 'true';
+
+    if (!isLoading) {
+      delete button.dataset.ajaxOriginalDisabled;
+      delete button.dataset.ajaxOriginalText;
+      delete button.dataset.ajaxOriginalValue;
+    }
+  }
+
+  function setFormLoading(form, isLoading, loadingText = DEFAULT_LOADING_TEXT) {
+    form.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+
+    for (const button of getSubmitButtons(form)) {
+      setButtonLoading(button, isLoading, loadingText);
+    }
+  }
+
+  function serializeForm(form) {
+    const values = {};
+    const formData = new FormData(form);
+
+    for (const [key, value] of formData.entries()) {
+      if (Object.prototype.hasOwnProperty.call(values, key)) {
+        values[key] = Array.isArray(values[key]) ? values[key].concat(value) : [values[key], value];
+      } else {
+        values[key] = value;
+      }
+    }
+
+    return values;
+  }
+
+  function clearFieldErrors(form) {
+    for (const element of form.querySelectorAll('[data-field-error], [data-error-for]')) {
+      writeMessage(element, '');
+    }
+
+    for (const field of form.querySelectorAll('[aria-invalid="true"]')) {
+      field.removeAttribute('aria-invalid');
+    }
+  }
+
+  function clearFormFeedback(form) {
+    writeMessage(getMessageTarget(form, 'ajaxErrorTarget', '[data-ajax-error]'), '');
+    writeMessage(getMessageTarget(form, 'ajaxSuccessTarget', '[data-ajax-success]'), '');
+    clearFieldErrors(form);
+    announce(form, '');
+  }
+
+  function normalizeFieldErrors(errors) {
+    if (!errors || typeof errors !== 'object') {
+      return [];
+    }
+
+    if (Array.isArray(errors)) {
+      return errors
+        .map((error) => ({
+          field: error.field || error.name,
+          message: error.message || error.error || ''
+        }))
+        .filter((error) => error.field && error.message);
+    }
+
+    return Object.entries(errors)
+      .map(([field, message]) => ({
+        field,
+        message: Array.isArray(message) ? message.join(' ') : String(message)
+      }))
+      .filter((error) => error.field && error.message);
+  }
+
+  function findFieldErrorElement(form, field) {
+    return Array.from(form.querySelectorAll('[data-field-error], [data-error-for]')).find(
+      (element) => element.dataset.fieldError === field || element.dataset.errorFor === field
+    );
+  }
+
+  function markFieldInvalid(form, fieldName) {
+    const field = form.elements[fieldName];
+
+    if (field && typeof field.setAttribute === 'function') {
+      field.setAttribute('aria-invalid', 'true');
+      return;
+    }
+
+    if (field && typeof field.length === 'number') {
+      for (const fieldOption of Array.from(field)) {
+        fieldOption.setAttribute('aria-invalid', 'true');
+      }
+    }
+  }
+
+  function renderFieldErrors(form, errors) {
+    for (const error of normalizeFieldErrors(errors)) {
+      markFieldInvalid(form, error.field);
+      writeMessage(findFieldErrorElement(form, error.field), error.message);
+    }
+  }
+
+  async function parseJsonSafely(response) {
+    const text = await response.text();
+
+    if (!text) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      return {
+        success: false,
+        error: 'The server returned an invalid JSON response.'
+      };
+    }
+  }
+
+  function normalizeAjaxResponse(response, payload) {
+    const success = response.ok && payload?.success !== false;
+    const fallbackMessage = response.statusText || DEFAULT_ERROR_MESSAGE;
+    const message = payload?.message || payload?.error || (success ? DEFAULT_SUCCESS_MESSAGE : fallbackMessage);
+
+    return {
+      success,
+      status: response.status,
+      data: payload?.data ?? (success ? payload : null),
+      error: success ? null : message,
+      fieldErrors: payload?.fieldErrors || payload?.errors || null,
+      message,
+      response,
+      payload
+    };
+  }
+
+  function buildRequestUrl(url, payload) {
+    const requestUrl = new URL(url, window.location.href);
+
+    for (const [key, value] of Object.entries(payload)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          requestUrl.searchParams.append(key, item);
+        }
+      } else {
+        requestUrl.searchParams.set(key, value);
+      }
+    }
+
+    return requestUrl.toString();
+  }
+
+  async function submitAjaxForm(form, options = {}) {
+    if (!isForm(form)) {
+      throw new TypeError('submitAjaxForm expects a form element.');
+    }
+
+    const method = String(options.method || form.method || 'POST').toUpperCase();
+    const loadingText = options.loadingText || form.dataset.loadingText || DEFAULT_LOADING_TEXT;
+    const payload = options.getPayload ? options.getPayload(form) : serializeForm(form);
+    const url = options.url || form.action || window.location.href;
+    const requestUrl = method === 'GET' ? buildRequestUrl(url, payload) : url;
+    const headers = {
+      Accept: JSON_CONTENT_TYPE,
+      ...(method === 'GET' ? {} : { 'Content-Type': JSON_CONTENT_TYPE }),
+      ...(options.headers || {})
+    };
+
+    clearFormFeedback(form);
+    setFormLoading(form, true, loadingText);
+
+    try {
+      const response = await (options.fetchImpl || window.fetch)(requestUrl, {
+        method,
+        headers,
+        credentials: options.credentials || 'same-origin',
+        body: method === 'GET' ? undefined : JSON.stringify(payload)
+      });
+      const result = normalizeAjaxResponse(response, await parseJsonSafely(response));
+
+      if (!result.success) {
+        renderFieldErrors(form, result.fieldErrors);
+        writeMessage(getMessageTarget(form, 'ajaxErrorTarget', '[data-ajax-error]'), result.error);
+        announce(form, result.error);
+        options.onError?.(result, form);
+        return result;
+      }
+
+      writeMessage(getMessageTarget(form, 'ajaxSuccessTarget', '[data-ajax-success]'), result.message);
+      announce(form, result.message || DEFAULT_SUCCESS_MESSAGE);
+
+      if (options.resetOnSuccess || form.dataset.ajaxReset === 'true') {
+        form.reset();
+      }
+
+      options.onSuccess?.(result, form);
+      return result;
+    } catch (error) {
+      const result = {
+        success: false,
+        status: 0,
+        data: null,
+        error: error.message || DEFAULT_ERROR_MESSAGE,
+        fieldErrors: null,
+        message: error.message || DEFAULT_ERROR_MESSAGE,
+        response: null,
+        payload: null
+      };
+
+      writeMessage(getMessageTarget(form, 'ajaxErrorTarget', '[data-ajax-error]'), result.error);
+      announce(form, result.error);
+      options.onError?.(result, form);
+      return result;
+    } finally {
+      setFormLoading(form, false, loadingText);
+    }
+  }
+
+  function attachAjaxForm(form, options = {}) {
+    if (!isForm(form)) {
+      throw new TypeError('attachAjaxForm expects a form element.');
+    }
+
+    const handleSubmit = (event) => {
+      event.preventDefault();
+      submitAjaxForm(form, options);
+    };
+
+    form.addEventListener('submit', handleSubmit);
+
+    return () => form.removeEventListener('submit', handleSubmit);
+  }
+
+  function attachAjaxForms(selector = 'form[data-ajax-form]', options = {}) {
+    return Array.from(document.querySelectorAll(selector)).map((form) => attachAjaxForm(form, options));
+  }
+
+  window.LeaseWiseAjaxForms = Object.freeze({
+    attachAjaxForm,
+    attachAjaxForms,
+    clearFormFeedback,
+    normalizeAjaxResponse,
+    parseJsonSafely,
+    renderFieldErrors,
+    serializeForm,
+    setFormLoading,
+    submitAjaxForm
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => attachAjaxForms(), { once: true });
+  } else {
+    attachAjaxForms();
+  }
+})();

--- a/services/leasewise-service.js
+++ b/services/leasewise-service.js
@@ -10,7 +10,7 @@ export function getPagePlaceholder({ title, routeGroup, description, pagePath, t
       pagePath,
       todoItems
     }),
-    scripts: ['/public/js/app.js']
+    scripts: ['/public/js/ajax-form.js', '/public/js/app.js']
   };
 }
 


### PR DESCRIPTION
## Summary

Implemented front-end issue 5: Create a reusable AJAX form helper.

## What Changed

- Added a reusable browser-side AJAX form helper in [public/js/ajax-form.js](/Users/steve/Desktop/CS-546-B-FP/front-end-main/public/js/ajax-form.js:1).
- Supports shared form submission behavior for future auth, review, and shortlist forms:
  - automatic `form[data-ajax-form]` binding
  - submit-button loading and disabled state
  - safe JSON response parsing
  - normalized success/error responses
  - success and error message rendering
  - field-level error rendering with `aria-invalid`
  - optional success reset behavior
- Loaded the helper before the existing app script in [services/leasewise-service.js](/Users/steve/Desktop/CS-546-B-FP/front-end-main/services/leasewise-service.js:13).

## Behavior Impact

Future forms can opt in with `data-ajax-form` and reuse one shared submission flow instead of duplicating fetch/loading/error code.

## Files Changed

- [public/js/ajax-form.js](/Users/steve/Desktop/CS-546-B-FP/front-end-main/public/js/ajax-form.js:1)
- [services/leasewise-service.js](/Users/steve/Desktop/CS-546-B-FP/front-end-main/services/leasewise-service.js:13)

## Testing

- Passed `node --check public/js/ajax-form.js`.
- Ran a simulated form submission test covering success response, field-error response, disabled-button restoration, and attach/cleanup behavior.
- Started the front-end with `PORT=4322 npm start`.
- Confirmed `GET /` returned `200 OK` and included `/public/js/ajax-form.js`.

## Notes

Current auth/review/shortlist pages are still placeholders, so this PR adds the reusable helper layer without wiring it to real forms yet.