### PR TITLE
Add loading states for auth forms

### DIFF
--- a/public/js/loading-form.js
+++ b/public/js/loading-form.js
@@ -1,0 +1,26 @@
+(() => {
+  const forms = document.querySelectorAll("form[data-loading-form]");
+
+  for (const form of forms) {
+    form.addEventListener("submit", () => {
+      const loadingText = form.dataset.loadingText || "Loading...";
+      const buttons = form.querySelectorAll(
+        'button[type="submit"], input[type="submit"]',
+      );
+
+      form.setAttribute("aria-busy", "true");
+
+      for (const button of buttons) {
+        if (button.tagName === "INPUT") {
+          button.dataset.originalValue = button.value;
+          button.value = loadingText;
+        } else {
+          button.dataset.originalText = button.textContent;
+          button.textContent = loadingText;
+        }
+
+        button.disabled = true;
+      }
+    });
+  }
+})();

--- a/public/js/loading-form.js
+++ b/public/js/loading-form.js
@@ -1,16 +1,20 @@
 (() => {
-  const forms = document.querySelectorAll("form[data-loading-form]");
+  function getSubmitButtons(form) {
+    return Array.from(
+      form.querySelectorAll(
+        'button:not([type]), button[type="submit"], input[type="submit"]',
+      ),
+    );
+  }
 
-  for (const form of forms) {
-    form.addEventListener("submit", () => {
-      const loadingText = form.dataset.loadingText || "Loading...";
-      const buttons = form.querySelectorAll(
-        'button[type="submit"], input[type="submit"]',
-      );
+  function setLoading(form, isLoading) {
+    const loadingText = form.dataset.loadingText || "Loading...";
+    const buttons = getSubmitButtons(form);
 
-      form.setAttribute("aria-busy", "true");
+    form.setAttribute("aria-busy", isLoading ? "true" : "false");
 
-      for (const button of buttons) {
+    for (const button of buttons) {
+      if (isLoading) {
         if (button.tagName === "INPUT") {
           button.dataset.originalValue = button.value;
           button.value = loadingText;
@@ -18,9 +22,39 @@
           button.dataset.originalText = button.textContent;
           button.textContent = loadingText;
         }
-
         button.disabled = true;
+      } else {
+        if (button.tagName === "INPUT") {
+          button.value = button.dataset.originalValue || button.value;
+          delete button.dataset.originalValue;
+        } else {
+          button.textContent = button.dataset.originalText || button.textContent;
+          delete button.dataset.originalText;
+        }
+        button.disabled = false;
+      }
+    }
+  }
+
+  function init() {
+    const forms = document.querySelectorAll("form[data-loading-form]");
+
+    for (const form of forms) {
+      form.addEventListener("submit", () => {
+        setLoading(form, true);
+      });
+    }
+
+    window.addEventListener("pageshow", () => {
+      for (const form of document.querySelectorAll("form[data-loading-form]")) {
+        setLoading(form, false);
       }
     });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
   }
 })();

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -6,6 +6,7 @@ import {
 } from "../utils/errors.js";
 
 const router = Router();
+const AUTH_SCRIPTS = ["/public/js/loading-form.js", "/public/js/app.js"];
 
 router.get("/login", (req, res) => {
   if (req.session.user) return res.redirect("/");
@@ -13,6 +14,7 @@ router.get("/login", (req, res) => {
     pageTitle: "Login — LeaseWise NYC",
     formData: {},
     errors: [],
+    scripts: AUTH_SCRIPTS,
   });
 });
 
@@ -24,6 +26,7 @@ router.post("/login", async (req, res) => {
       pageTitle: "Login — LeaseWise NYC",
       formData: { username },
       errors: [{ message: "Username and password are required." }],
+      scripts: AUTH_SCRIPTS,
     });
   }
 
@@ -42,6 +45,7 @@ router.post("/login", async (req, res) => {
             ),
           },
         ],
+        scripts: AUTH_SCRIPTS,
       });
     }
 
@@ -60,6 +64,7 @@ router.post("/login", async (req, res) => {
       pageTitle: "Login — LeaseWise NYC",
       formData: { username },
       errors: [{ message: getUnexpectedErrorMessage() }],
+      scripts: AUTH_SCRIPTS,
     });
   }
 });
@@ -70,6 +75,7 @@ router.get("/register", (req, res) => {
     pageTitle: "Register — LeaseWise NYC",
     formData: {},
     errors: [],
+    scripts: AUTH_SCRIPTS,
   });
 });
 
@@ -81,6 +87,7 @@ router.post("/register", async (req, res) => {
       pageTitle: "Register — LeaseWise NYC",
       formData: { firstName, lastName, email, username },
       errors: [{ message: "All fields are required." }],
+      scripts: AUTH_SCRIPTS,
     });
   }
 
@@ -105,6 +112,7 @@ router.post("/register", async (req, res) => {
             ),
           },
         ],
+        scripts: AUTH_SCRIPTS,
       });
     }
 
@@ -114,6 +122,7 @@ router.post("/register", async (req, res) => {
       pageTitle: "Register — LeaseWise NYC",
       formData: { firstName, lastName, email, username },
       errors: [{ message: getUnexpectedErrorMessage() }],
+      scripts: AUTH_SCRIPTS,
     });
   }
 });

--- a/views/auth/login.handlebars
+++ b/views/auth/login.handlebars
@@ -8,7 +8,7 @@
 
     {{> error-summary errors=errors}}
 
-    <form class="auth-form" id="login-form" action="/login" method="POST" novalidate>
+    <form class="auth-form" id="login-form" action="/login" method="POST" novalidate data-loading-form data-loading-text="Signing in ...">
       <div class="form-field">
         <label for="username">{{t "auth.usernameLabel"}}</label>
         <input id="username" name="username" type="text" autocomplete="username" placeholder="{{t "auth.usernamePlaceholder"}}" required value="{{formData.username}}">

--- a/views/auth/login.handlebars
+++ b/views/auth/login.handlebars
@@ -8,7 +8,7 @@
 
     {{> error-summary errors=errors}}
 
-    <form class="auth-form" id="login-form" action="/login" method="POST" novalidate data-loading-form data-loading-text="Signing in ...">
+    <form class="auth-form" id="login-form" action="/login" method="POST" novalidate data-loading-form data-loading-text="Signing in...">
       <div class="form-field">
         <label for="username">{{t "auth.usernameLabel"}}</label>
         <input id="username" name="username" type="text" autocomplete="username" placeholder="{{t "auth.usernamePlaceholder"}}" required value="{{formData.username}}">

--- a/views/auth/register.handlebars
+++ b/views/auth/register.handlebars
@@ -8,7 +8,7 @@
 
     {{> error-summary errors=errors}}
 
-<form class="auth-form" id="register-form" action="/register" method="POST" novalidate data-loading-form data-loading-text="Creating account..." >
+    <form class="auth-form" id="register-form" action="/register" method="POST" novalidate data-loading-form data-loading-text="Creating account...">
       <div class="form-grid">
         <div class="form-field">
           <label for="firstName">{{t "auth.firstNameLabel"}}</label>
@@ -35,9 +35,9 @@
         <label for="confirmPassword">{{t "auth.confirmPasswordLabel"}}</label>
         <input id="confirmPassword" name="confirmPassword" type="password" autocomplete="new-password" placeholder="{{t "auth.confirmPasswordPlaceholder"}}" required>
       </div>
-      <button class="button button-primary auth-submit" type="submit"> {{t "auth.registerEyebrow"}}</button>
+      <button class="button button-primary auth-submit" type="submit">{{t "auth.registerEyebrow"}}</button>
     </form>
-    
+
     <p class="auth-switch">
       {{t "auth.hasAccount"}} <a href="/login">{{t "auth.signIn"}}</a>
     </p>

--- a/views/auth/register.handlebars
+++ b/views/auth/register.handlebars
@@ -8,7 +8,7 @@
 
     {{> error-summary errors=errors}}
 
-    <form class="auth-form" id="register-form" action="/register" method="POST" novalidate>
+<form class="auth-form" id="register-form" action="/register" method="POST" novalidate data-loading-form data-loading-text="Creating account..." >
       <div class="form-grid">
         <div class="form-field">
           <label for="firstName">{{t "auth.firstNameLabel"}}</label>
@@ -35,9 +35,9 @@
         <label for="confirmPassword">{{t "auth.confirmPasswordLabel"}}</label>
         <input id="confirmPassword" name="confirmPassword" type="password" autocomplete="new-password" placeholder="{{t "auth.confirmPasswordPlaceholder"}}" required>
       </div>
-      <button class="button button-primary auth-submit" type="submit">{{t "auth.registerEyebrow"}}</button>
+      <button class="button button-primary auth-submit" type="submit"> {{t "auth.registerEyebrow"}}</button>
     </form>
-
+    
     <p class="auth-switch">
       {{t "auth.hasAccount"}} <a href="/login">{{t "auth.signIn"}}</a>
     </p>


### PR DESCRIPTION
Added loading states for auth form submissions.

Changes:
- Added shared loading-form.js helper
- Disabled submit buttons while forms are processing
- Updated login and register forms with loading text
- Included loading script on auth routes

Tested:
- Login button changes to Signing in...
- Register button changes to Creating account...
- Submit buttons are disabled during processing

Addresses #32