### PR TITLE
Complete watchlist toggle behavior

### DIFF
--- a/locales/en.js
+++ b/locales/en.js
@@ -117,7 +117,9 @@ export default {
     subtitle: 'Buildings you are tracking.',
     emptyTitle: 'Your watchlist is empty',
     emptyMessage: 'Browse buildings and click Watch to save them here.',
-    browseBuildings: 'Browse buildings'
+    browseBuildings: 'Browse buildings',
+    toggleFailed: 'Failed to update watchlist.',
+    toggleNetworkError: 'Unable to update watchlist. Please try again.'
   },
   compare: {
     title: 'Compare Buildings',

--- a/locales/zh-CN.js
+++ b/locales/zh-CN.js
@@ -117,7 +117,9 @@ export default {
     subtitle: '您正在追踪的建筑。',
     emptyTitle: '关注列表为空',
     emptyMessage: '浏览建筑并点击"关注"将其保存到此处。',
-    browseBuildings: '浏览建筑'
+    browseBuildings: '浏览建筑',
+    toggleFailed: '更新关注列表失败。',
+    toggleNetworkError: '无法更新关注列表，请重试。'
   },
   compare: {
     title: '建筑对比',

--- a/public/js/watchlist.js
+++ b/public/js/watchlist.js
@@ -1,35 +1,69 @@
 (function () {
-  document.addEventListener('click', async (e) => {
-    const btn = e.target.closest('.watchlist-btn');
+  function setStatusMessage(form, message) {
+    let status = form.querySelector("[data-watchlist-error]");
+
+    if (!status) {
+      status = document.createElement("div");
+      status.className = "error-message";
+      status.setAttribute("role", "alert");
+      status.dataset.watchlistError = "true";
+      form.appendChild(status);
+    }
+
+    status.textContent = message || "";
+    status.hidden = !message;
+  }
+
+  function updateButton(btn, watching) {
+    btn.setAttribute("aria-pressed", String(watching));
+    btn.dataset.watching = String(watching);
+    btn.textContent = watching ? "Watching" : "Watch";
+  }
+
+  document.addEventListener("click", async (e) => {
+    const btn = e.target.closest(".watchlist-btn");
     if (!btn) return;
 
-    const form = btn.closest('form');
+    const form = btn.closest("form");
     if (!form) return;
 
     e.preventDefault();
 
-    const action = form.getAttribute('action') || '';
+    const action = form.getAttribute("action") || "";
     const match = action.match(/\/watchlist\/(.+)/);
     if (!match) return;
 
     const buildingId = match[1];
+    const previousWatching =
+      btn.dataset.watching === "true" ||
+      btn.getAttribute("aria-pressed") === "true";
+
+    const nextWatching = !previousWatching;
+
+    setStatusMessage(form, "");
+    updateButton(btn, nextWatching);
     btn.disabled = true;
 
     try {
-      const res = await fetch('/api/watchlist/toggle', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ buildingId })
+      const res = await fetch("/api/watchlist/toggle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ buildingId }),
       });
-      const data = await res.json();
 
-      if (data.success) {
-        const watching = data.data.watching;
-        btn.setAttribute('aria-pressed', String(watching));
-        btn.textContent = watching ? 'Watching' : 'Watch';
+      const data = await res.json().catch(() => null);
+
+      if (!res.ok || data?.success === false) {
+        updateButton(btn, previousWatching);
+        setStatusMessage(form, data?.error || "Failed to update watchlist.");
+        return;
       }
+
+      const watching = Boolean(data?.data?.watching);
+      updateButton(btn, watching);
     } catch {
-      form.submit();
+      updateButton(btn, previousWatching);
+      setStatusMessage(form, "Unable to update watchlist. Please try again.");
     } finally {
       btn.disabled = false;
     }

--- a/public/js/watchlist.js
+++ b/public/js/watchlist.js
@@ -17,7 +17,9 @@
   function updateButton(btn, watching) {
     btn.setAttribute("aria-pressed", String(watching));
     btn.dataset.watching = String(watching);
-    btn.textContent = watching ? "Watching" : "Watch";
+    btn.textContent = watching
+      ? (btn.dataset.textWatching || "Watching")
+      : (btn.dataset.textWatch || "Watch");
   }
 
   document.addEventListener("click", async (e) => {
@@ -55,7 +57,7 @@
 
       if (!res.ok || data?.success === false) {
         updateButton(btn, previousWatching);
-        setStatusMessage(form, data?.error || "Failed to update watchlist.");
+        setStatusMessage(form, data?.error || form.dataset.errorFailed || "Failed to update watchlist.");
         return;
       }
 
@@ -63,7 +65,7 @@
       updateButton(btn, watching);
     } catch {
       updateButton(btn, previousWatching);
-      setStatusMessage(form, "Unable to update watchlist. Please try again.");
+      setStatusMessage(form, form.dataset.errorNetwork || "Unable to update watchlist. Please try again.");
     } finally {
       btn.disabled = false;
     }

--- a/views/buildings/detail.handlebars
+++ b/views/buildings/detail.handlebars
@@ -10,7 +10,12 @@
     {{#if currentUser}}
       <form method="POST" action="/watchlist/{{building._id}}">
         <input type="hidden" name="_method" value="{{#if isWatched}}DELETE{{else}}PUT{{/if}}" />
-        <button class="button {{#if isWatched}}button-ghost{{else}}button-primary{{/if}}" type="submit">
+        <button
+         class="watchlist-btn button {{#if isWatched}}button-ghost{{else}}button-primary{{/if}}"
+         type="submit"
+          aria-pressed="{{#if isWatched}}true{{else}}false{{/if}}"
+          data-watching="{{#if isWatched}}true{{else}}false{{/if}}"
+        >
           {{#if isWatched}}{{t "buildings.removeWatchlist"}}{{else}}{{t "buildings.addWatchlist"}}{{/if}}
         </button>
       </form>

--- a/views/buildings/detail.handlebars
+++ b/views/buildings/detail.handlebars
@@ -8,13 +8,15 @@
       {{/if}}
     </div>
     {{#if currentUser}}
-      <form method="POST" action="/watchlist/{{building._id}}">
+      <form method="POST" action="/watchlist/{{building._id}}" data-error-failed="{{t "watchlist.toggleFailed"}}" data-error-network="{{t "watchlist.toggleNetworkError"}}">
         <input type="hidden" name="_method" value="{{#if isWatched}}DELETE{{else}}PUT{{/if}}" />
         <button
          class="watchlist-btn button {{#if isWatched}}button-ghost{{else}}button-primary{{/if}}"
          type="submit"
           aria-pressed="{{#if isWatched}}true{{else}}false{{/if}}"
           data-watching="{{#if isWatched}}true{{else}}false{{/if}}"
+          data-text-watching="{{t "buildings.removeWatchlist"}}"
+          data-text-watch="{{t "buildings.addWatchlist"}}"
         >
           {{#if isWatched}}{{t "buildings.removeWatchlist"}}{{else}}{{t "buildings.addWatchlist"}}{{/if}}
         </button>

--- a/views/partials/building-card.handlebars
+++ b/views/partials/building-card.handlebars
@@ -11,10 +11,12 @@
       {{#if building.reviewCount}}{{building.reviewCount}} {{t "reviews.delete"}}{{else}}{{t "buildings.noReviewsYet"}}{{/if}}
     </span>
     {{#if currentUser}}
-      <form method="POST" action="/watchlist/{{building._id}}">
+      <form method="POST" action="/watchlist/{{building._id}}" data-error-failed="{{t "watchlist.toggleFailed"}}" data-error-network="{{t "watchlist.toggleNetworkError"}}">
         <input type="hidden" name="_method" value="{{#if isWatched}}DELETE{{else}}PUT{{/if}}" />
         <button class="watchlist-btn" type="submit"
           data-watching="{{#if isWatched}}true{{else}}false{{/if}}"
+          data-text-watching="{{t "buildings.watching"}}"
+          data-text-watch="{{t "buildings.watch"}}"
           aria-pressed="{{#if isWatched}}true{{else}}false{{/if}}"
           aria-label="{{#if isWatched}}{{t "buildings.removeWatchlist"}}{{else}}{{t "buildings.addWatchlist"}}{{/if}}">
           {{#if isWatched}}{{t "buildings.watching"}}{{else}}{{t "buildings.watch"}}{{/if}}

--- a/views/partials/building-card.handlebars
+++ b/views/partials/building-card.handlebars
@@ -14,6 +14,7 @@
       <form method="POST" action="/watchlist/{{building._id}}">
         <input type="hidden" name="_method" value="{{#if isWatched}}DELETE{{else}}PUT{{/if}}" />
         <button class="watchlist-btn" type="submit"
+          data-watching="{{#if isWatched}}true{{else}}false{{/if}}"
           aria-pressed="{{#if isWatched}}true{{else}}false{{/if}}"
           aria-label="{{#if isWatched}}{{t "buildings.removeWatchlist"}}{{else}}{{t "buildings.addWatchlist"}}{{/if}}">
           {{#if isWatched}}{{t "buildings.watching"}}{{else}}{{t "buildings.watch"}}{{/if}}


### PR DESCRIPTION
Implemented AJAX watchlist toggle behavior.

Changes:
- Added optimistic UI update for watchlist buttons
- Disabled button during request
- Restored previous state on API failure
- Added inline error feedback for failed toggle requests
- Wired detail page and building cards to watchlist.js

Tested:
- Add to watchlist
- Remove from watchlist
- Watchlist page remove behavior

Closes #25