### PR TITLE
feat: add csrf protection

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ import methodOverride from 'method-override';
 
 import registerRoutes from './routes/index.js';
 import { registerHandlebarsHelpers } from './config/handlebars-helpers.js';
+import { attachCsrfToken, validateCsrfToken } from './middleware/csrf.js';
 import { attachViewContext } from './middleware/view-context.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -42,7 +43,9 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(methodOverride('_method'));
 
+app.use(attachCsrfToken);
 app.use(attachViewContext);
+app.use(validateCsrfToken);
 registerRoutes(app);
 
 app.listen(port, () => {

--- a/locales/en.js
+++ b/locales/en.js
@@ -35,7 +35,9 @@ export default {
     notFoundTitle: 'Page not found',
     notFoundMessage: 'The page you requested is not available.',
     unexpectedTitle: 'Something went wrong',
-    unexpectedMessage: 'An unexpected error occurred. Please try again later.'
+    unexpectedMessage: 'An unexpected error occurred. Please try again later.',
+    forbiddenTitle: 'Access denied',
+    forbiddenMessage: 'You do not have permission to access this page.'
   },
   footer: {
     note: 'LeaseWise NYC — Data sourced from NYC Open Data.'

--- a/locales/zh-CN.js
+++ b/locales/zh-CN.js
@@ -35,7 +35,9 @@ export default {
     notFoundTitle: '页面不存在',
     notFoundMessage: '当前页面暂不可用。',
     unexpectedTitle: '发生错误',
-    unexpectedMessage: '出现了未预期错误，请稍后再试。'
+    unexpectedMessage: '出现了未预期错误，请稍后再试。',
+    forbiddenTitle: '禁止访问',
+    forbiddenMessage: '你没有访问此页面的权限。'
   },
   footer: {
     note: 'LeaseWise NYC — 数据来源于纽约市开放数据。'

--- a/middleware/csrf.js
+++ b/middleware/csrf.js
@@ -1,0 +1,79 @@
+import crypto from 'crypto';
+
+const CSRF_TOKEN_BYTES = 32;
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+const CSRF_ERROR_MESSAGE = 'Invalid CSRF token. Please refresh the page and try again.';
+
+export const CSRF_FIELD_NAME = '_csrf';
+export const CSRF_HEADER_NAME = 'x-csrf-token';
+
+const createCsrfToken = () => crypto.randomBytes(CSRF_TOKEN_BYTES).toString('hex');
+
+const getSessionToken = (req) => {
+  if (!req.session) {
+    return '';
+  }
+
+  if (!req.session.csrfToken) {
+    req.session.csrfToken = createCsrfToken();
+  }
+
+  return req.session.csrfToken;
+};
+
+const getRequestToken = (req) =>
+  req.get(CSRF_HEADER_NAME) ||
+  req.get('csrf-token') ||
+  req.body?.[CSRF_FIELD_NAME] ||
+  '';
+
+const tokensMatch = (expected, received) => {
+  if (typeof expected !== 'string' || typeof received !== 'string') {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected);
+  const receivedBuffer = Buffer.from(received);
+
+  return (
+    expectedBuffer.length === receivedBuffer.length &&
+    crypto.timingSafeEqual(expectedBuffer, receivedBuffer)
+  );
+};
+
+const wantsJson = (req) =>
+  req.path.startsWith('/api/') ||
+  req.get('accept')?.includes('application/json') ||
+  req.get('content-type')?.includes('application/json');
+
+const rejectCsrfRequest = (req, res) => {
+  if (wantsJson(req)) {
+    return res.status(403).json({ success: false, error: CSRF_ERROR_MESSAGE });
+  }
+
+  return res.status(403).render('errors/500', {
+    pageTitle: 'Forbidden - LeaseWise NYC',
+    heading: 'Forbidden',
+    message: CSRF_ERROR_MESSAGE
+  });
+};
+
+export function attachCsrfToken(req, res, next) {
+  res.locals.csrfToken = getSessionToken(req);
+  return next();
+}
+
+export function validateCsrfToken(req, res, next) {
+  if (SAFE_METHODS.has(req.method)) {
+    return next();
+  }
+
+  const expectedToken = getSessionToken(req);
+  const requestToken = getRequestToken(req);
+
+  if (!tokensMatch(expectedToken, requestToken)) {
+    return rejectCsrfRequest(req, res);
+  }
+
+  return next();
+}

--- a/middleware/csrf.js
+++ b/middleware/csrf.js
@@ -51,10 +51,8 @@ const rejectCsrfRequest = (req, res) => {
     return res.status(403).json({ success: false, error: CSRF_ERROR_MESSAGE });
   }
 
-  return res.status(403).render('errors/500', {
-    pageTitle: 'Forbidden - LeaseWise NYC',
-    heading: 'Forbidden',
-    message: CSRF_ERROR_MESSAGE
+  return res.status(403).render('errors/403', {
+    pageTitle: 'Forbidden - LeaseWise NYC'
   });
 };
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -119,6 +119,25 @@ code {
   text-decoration: underline;
 }
 
+.site-nav__form {
+  margin: 0;
+}
+
+.site-nav__button {
+  background: none;
+  border: 0;
+  color: var(--color-accent-strong);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+}
+
+.site-nav__button:hover {
+  color: var(--color-accent);
+}
+
 .site-header__meta {
   align-items: center;
   display: flex;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,33 @@
 (() => {
   document.documentElement.dataset.appMode = 'live';
+
+  const unsafeMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+  const originalFetch = window.fetch?.bind(window);
+
+  function getCsrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+  }
+
+  function isSameOriginRequest(input) {
+    const requestUrl = input instanceof Request ? input.url : String(input);
+    return new URL(requestUrl, window.location.href).origin === window.location.origin;
+  }
+
+  if (originalFetch) {
+    window.fetch = function fetchWithCsrf(input, init = {}) {
+      const method = String(init.method || (input instanceof Request ? input.method : 'GET')).toUpperCase();
+      const token = getCsrfToken();
+
+      if (!unsafeMethods.has(method) || !token || !isSameOriginRequest(input)) {
+        return originalFetch(input, init);
+      }
+
+      const headers = new Headers(init.headers || (input instanceof Request ? input.headers : undefined));
+      if (!headers.has('X-CSRF-Token')) {
+        headers.set('X-CSRF-Token', token);
+      }
+
+      return originalFetch(input, { ...init, headers });
+    };
+  }
 })();

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -127,7 +127,7 @@ router.post("/register", async (req, res) => {
   }
 });
 
-router.get("/logout", (req, res) => {
+router.post("/logout", (req, res) => {
   const cookie = req.session.backendCookie;
   if (cookie) {
     api.auth.logout(cookie).catch(() => {});
@@ -136,5 +136,7 @@ router.get("/logout", (req, res) => {
     res.redirect("/");
   });
 });
+
+router.get("/logout", (req, res) => res.redirect("/"));
 
 export default router;

--- a/views/account.handlebars
+++ b/views/account.handlebars
@@ -6,6 +6,7 @@
   <h2 class="section-title">{{t "account.profileSection"}}</h2>
   {{> error-summary errors=errors}}
   <form method="POST" action="/account" style="display:grid;gap:var(--space-md);max-width:32rem">
+    {{> csrf-field}}
     <div class="form-grid">
       <div class="form-field">
         <label for="firstName">{{t "account.firstName"}}</label>
@@ -32,6 +33,7 @@
   <h2 class="section-title">{{t "account.passwordSection"}}</h2>
   {{> error-summary errors=passwordErrors}}
   <form method="POST" action="/account/password" style="display:grid;gap:var(--space-md);max-width:32rem">
+    {{> csrf-field}}
     <div class="form-field">
       <label for="currentPassword">{{t "account.currentPassword"}}</label>
       <input id="currentPassword" name="currentPassword" type="password" autocomplete="current-password" required />

--- a/views/admin/buildings/form.handlebars
+++ b/views/admin/buildings/form.handlebars
@@ -5,6 +5,7 @@
 <div class="content-panel" style="max-width:48rem">
   {{> error-summary errors=errors}}
   <form method="POST" action="{{#if building._id}}/admin/buildings/{{building._id}}{{else}}/admin/buildings{{/if}}">
+    {{> csrf-field}}
     {{#if building._id}}<input type="hidden" name="_method" value="PUT" />{{/if}}
 
     <div style="display:grid;gap:var(--space-md)">

--- a/views/admin/reviews/index.handlebars
+++ b/views/admin/reviews/index.handlebars
@@ -46,12 +46,14 @@
                 <div class="admin-actions">
                   {{#unless this.isFlagged}}
                     <form method="POST" action="/admin/reviews/{{this._id}}/flag">
+                      {{> csrf-field}}
                       <button type="submit">{{t "admin.reviews.actions.flag"}}</button>
                     </form>
                   {{/unless}}
 
                   {{#unless this.isHidden}}
                     <form method="POST" action="/admin/reviews/{{this._id}}/hide">
+                      {{> csrf-field}}
                       <button type="submit">{{t "admin.reviews.actions.hide"}}</button>
                     </form>
                   {{/unless}}

--- a/views/admin/users/index.handlebars
+++ b/views/admin/users/index.handlebars
@@ -47,6 +47,7 @@
                 <div class="admin-actions">
                   {{#unless this.isAdmin}}
                     <form method="POST" action="/admin/users/{{this._id}}/promote">
+                      {{> csrf-field}}
                       <button type="submit">{{t "admin.users.actions.promote"}}</button>
                     </form>
                   {{/unless}}

--- a/views/auth/login.handlebars
+++ b/views/auth/login.handlebars
@@ -9,6 +9,7 @@
     {{> error-summary errors=errors}}
 
     <form class="auth-form" id="login-form" action="/login" method="POST" novalidate data-loading-form data-loading-text="Signing in...">
+      {{> csrf-field}}
       <div class="form-field">
         <label for="username">{{t "auth.usernameLabel"}}</label>
         <input id="username" name="username" type="text" autocomplete="username" placeholder="{{t "auth.usernamePlaceholder"}}" required value="{{formData.username}}">

--- a/views/auth/register.handlebars
+++ b/views/auth/register.handlebars
@@ -9,6 +9,7 @@
     {{> error-summary errors=errors}}
 
     <form class="auth-form" id="register-form" action="/register" method="POST" novalidate data-loading-form data-loading-text="Creating account...">
+      {{> csrf-field}}
       <div class="form-grid">
         <div class="form-field">
           <label for="firstName">{{t "auth.firstNameLabel"}}</label>

--- a/views/buildings/detail.handlebars
+++ b/views/buildings/detail.handlebars
@@ -9,6 +9,7 @@
     </div>
     {{#if currentUser}}
       <form method="POST" action="/watchlist/{{building._id}}">
+        {{> csrf-field}}
         <input type="hidden" name="_method" value="{{#if isWatched}}DELETE{{else}}PUT{{/if}}" />
         <button class="button {{#if isWatched}}button-ghost{{else}}button-primary{{/if}}" type="submit">
           {{#if isWatched}}{{t "buildings.removeWatchlist"}}{{else}}{{t "buildings.addWatchlist"}}{{/if}}
@@ -74,6 +75,7 @@
         <details style="margin-top:var(--space-lg)">
           <summary class="button button-primary" style="display:inline-block;cursor:pointer">{{t "buildings.writeReview"}}</summary>
           <form id="review-form" method="POST" action="/buildings/{{building._id}}/reviews" data-review-form style="margin-top:var(--space-md);display:grid;gap:var(--space-md)">
+            {{> csrf-field}}
             <div class="error-message" data-review-error aria-live="assertive" hidden></div>
 
             <div class="form-field">
@@ -113,6 +115,7 @@
       <div class="content-panel">
         <h2 class="section-title">{{t "buildings.addToShortlist"}}</h2>
         <form method="POST" action="/shortlists/add" style="display:grid;gap:var(--space-sm)">
+          {{> csrf-field}}
           <input type="hidden" name="buildingId" value="{{building._id}}" />
           <div class="form-field">
             <label for="shortlist-select">{{t "buildings.chooseShortlist"}}</label>

--- a/views/errors/403.handlebars
+++ b/views/errors/403.handlebars
@@ -1,0 +1,9 @@
+<section class="error-page">
+  <div class="shell-container">
+    <h1>403</h1>
+    <h2>{{t "errors.forbiddenTitle"}}</h2>
+
+    <p>{{t "errors.forbiddenMessage"}}</p>
+    <a href="/"> {{t "nav.home"}} </a>
+  </div>
+</section>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {{#if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}" />{{/if}}
     <title>{{pageTitle}}</title>
     <link rel="stylesheet" href="/public/css/tokens.css" />
     <link rel="stylesheet" href="/public/css/semantic-tokens.css" />

--- a/views/partials/building-card.handlebars
+++ b/views/partials/building-card.handlebars
@@ -12,6 +12,7 @@
     </span>
     {{#if currentUser}}
       <form method="POST" action="/watchlist/{{building._id}}">
+        {{> csrf-field}}
         <input type="hidden" name="_method" value="{{#if isWatched}}DELETE{{else}}PUT{{/if}}" />
         <button class="watchlist-btn" type="submit"
           aria-pressed="{{#if isWatched}}true{{else}}false{{/if}}"

--- a/views/partials/csrf-field.handlebars
+++ b/views/partials/csrf-field.handlebars
@@ -1,0 +1,1 @@
+{{#if csrfToken}}<input type="hidden" name="_csrf" value="{{csrfToken}}" />{{/if}}

--- a/views/partials/danger-dialog.handlebars
+++ b/views/partials/danger-dialog.handlebars
@@ -5,6 +5,7 @@
     <div class="dialog__actions">
       <button class="button button-ghost" type="button" data-dialog-close="{{dialogId}}">{{t "dialog.cancel"}}</button>
       <form method="POST" action="{{formAction}}">
+        {{> csrf-field}}
         {{#if formMethod}}<input type="hidden" name="_method" value="{{formMethod}}" />{{/if}}
         {{#each hiddenFields}}
           <input type="hidden" name="{{this.name}}" value="{{this.value}}" />

--- a/views/partials/note-form.handlebars
+++ b/views/partials/note-form.handlebars
@@ -1,4 +1,5 @@
 <form class="note-form" method="POST" action="/shortlists/{{shortlistId}}/items/{{itemId}}/note">
+  {{> csrf-field}}
   <label for="note-{{itemId}}" class="form-field label">{{t "noteForm.label"}}</label>
   <textarea
     id="note-{{itemId}}"

--- a/views/partials/site-header.handlebars
+++ b/views/partials/site-header.handlebars
@@ -34,7 +34,10 @@
           {{/if}}
 
           <li>
-            <a href="/logout">{{t "nav.logout"}}</a>
+            <form class="site-nav__form" method="POST" action="/logout">
+              {{> csrf-field}}
+              <button class="site-nav__button" type="submit">{{t "nav.logout"}}</button>
+            </form>
           </li>
         {{else}}
           <li>

--- a/views/shortlists/index.handlebars
+++ b/views/shortlists/index.handlebars
@@ -9,6 +9,7 @@
 
 <div style="margin-bottom:var(--space-lg)">
   <form method="POST" action="/shortlists" style="display:flex;gap:var(--space-sm);flex-wrap:wrap;align-items:flex-end">
+    {{> csrf-field}}
     <div class="form-field" style="flex:1 1 16rem">
       <label for="shortlist-name">{{t "shortlists.newNameLabel"}}</label>
       <input id="shortlist-name" name="name" type="text" placeholder="{{t "shortlists.newNamePlaceholder"}}" required />


### PR DESCRIPTION
## Summary

Implemented front-end issue #31: CSRF protection for state-changing operations.

## What Changed

- Added CSRF token generation and validation middleware.
- Stores one CSRF token per front-end session.
- Exposes the CSRF token to views through `res.locals.csrfToken`.
- Validates CSRF tokens for unsafe HTTP methods:
  - `POST`
  - `PUT`
  - `PATCH`
  - `DELETE`
- Accepts CSRF tokens from:
  - hidden form field `_csrf`
  - `X-CSRF-Token` request header
- Added a shared CSRF hidden field partial.
- Added CSRF hidden fields to state-changing forms across auth, account, buildings, shortlists, watchlist, admin users, admin buildings, and admin reviews.
- Added a CSRF meta tag to the main layout for client-side scripts.
- Added a global same-origin fetch wrapper that automatically adds `X-CSRF-Token` to AJAX state-changing requests.
- Changed logout from state-changing `GET /logout` to protected `POST /logout`.
- Kept `GET /logout` as a safe redirect only.
- Added small nav button styling so the logout POST form still matches the header navigation.

## Behavior Impact

State-changing front-end requests now require a valid CSRF token. Standard forms submit the token through a hidden field, and AJAX requests automatically include the token header. Requests missing or sending an invalid token receive `403`.

## Files Changed

- `app.js`
- `middleware/csrf.js`
- `public/css/main.css`
- `public/js/app.js`
- `routes/auth.js`
- `views/layouts/main.handlebars`
- `views/partials/csrf-field.handlebars`
- `views/partials/site-header.handlebars`
- `views/partials/building-card.handlebars`
- `views/partials/danger-dialog.handlebars`
- `views/partials/note-form.handlebars`
- `views/auth/login.handlebars`
- `views/auth/register.handlebars`
- `views/account.handlebars`
- `views/buildings/detail.handlebars`
- `views/shortlists/index.handlebars`
- `views/admin/buildings/form.handlebars`
- `views/admin/users/index.handlebars`
- `views/admin/reviews/index.handlebars`

## Testing

- Passed `node --check middleware/csrf.js`.
- Passed `node --check app.js`.
- Passed `node --check public/js/app.js`.
- Passed `node --check routes/auth.js`.
- Passed `node --check routes/site.js`.
- Passed `node --check routes/admin.js`.
- Passed `node --check routes/user.js`.
- Passed `node --check routes/api.js`.
- Passed `git diff --check`.
- Ran CSRF middleware behavior tests covering:
  - token generation
  - safe method bypass
  - header token validation
  - hidden form token validation
  - invalid token rejection
  - JSON `403` response for API requests
- Ran client fetch wrapper tests covering:
  - same-origin unsafe request token header injection
  - safe `GET` requests unchanged
  - cross-origin requests unchanged
- Started frontend with `PORT=4333 npm start`.
- Verified `/login` renders CSRF meta and hidden form token.
- Verified `/register` renders the CSRF hidden form token.
- Verified POST `/login` without CSRF returns `403`.
- Verified POST `/login` with CSRF passes CSRF validation.
- Verified AJAX POST `/api/watchlist/toggle` without CSRF returns JSON `403`.
- Verified AJAX POST `/api/watchlist/toggle` with `X-CSRF-Token` does not fail CSRF validation.
- Verified `GET /logout` safely redirects without changing session.
- Verified POST `/logout` without CSRF returns `403`.
- Stopped the local frontend test server.

## Notes

This PR only covers issue #31. It does not include API response adapters, authentication flow changes, or shortlist note editing work.
