### PR TITLE
feat: add api response view model adapters

### DIFF
--- a/adapters/view-models.js
+++ b/adapters/view-models.js
@@ -7,3 +7,236 @@ export function toPlaceholderPageModel({ title, routeGroup, description, pagePat
     todoItems
   };
 }
+
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
+const toIdString = (value) => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  return String(value);
+};
+
+const toDisplayString = (value, fallback = '') => {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  return String(value);
+};
+
+const getFullName = ({ firstName, lastName, name, username } = {}) => {
+  if (name) return toDisplayString(name);
+
+  const fullName = [firstName, lastName]
+    .filter(Boolean)
+    .map((part) => String(part).trim())
+    .filter(Boolean)
+    .join(' ');
+
+  return fullName || toDisplayString(username, '');
+};
+
+const normalizeRiskSummary = (building = {}) => {
+  const source =
+    building.riskSummary && typeof building.riskSummary === 'object'
+      ? { ...building.riskSummary }
+      : {};
+  const hasRiskData =
+    Object.keys(source).length > 0 ||
+    building.riskLevel !== undefined ||
+    building.riskScore !== undefined;
+
+  if (!hasRiskData) {
+    return undefined;
+  }
+
+  const riskLevel = source.level ?? building.riskLevel;
+  const riskScore = source.score ?? building.riskScore;
+
+  if (riskLevel !== undefined && riskLevel !== null && riskLevel !== '') {
+    source.level = String(riskLevel).toLowerCase();
+  }
+
+  if (riskScore !== undefined && riskScore !== null && riskScore !== '') {
+    source.score = Number(riskScore);
+  }
+
+  return source;
+};
+
+export function toBuildingViewModel(building = {}) {
+  const address = toDisplayString(building.streetAddress || building.address);
+  const ownerName = toDisplayString(
+    building.ownerName ||
+      (typeof building.owner === 'object' ? building.owner?.name : building.owner)
+  );
+  const owner =
+    ownerName
+      ? {
+          ...(typeof building.owner === 'object' ? building.owner : {}),
+          name: ownerName,
+          _id: encodeURIComponent(ownerName)
+        }
+      : building.owner;
+
+  return {
+    ...building,
+    _id: toIdString(building._id || building.id),
+    address,
+    streetAddress: building.streetAddress || address,
+    ownerName,
+    owner,
+    riskSummary: normalizeRiskSummary(building),
+    reviewCount: Number(building.reviewCount || 0),
+    averageRating: Number(building.averageRating || 0),
+    issueTagFrequency: building.issueTagFrequency || {}
+  };
+}
+
+export const toBuildingListViewModel = (buildings = []) =>
+  asArray(buildings).map(toBuildingViewModel);
+
+export function toBuildingSearchViewModel(apiPayload = {}) {
+  const items = asArray(apiPayload.items);
+  const total = Number(apiPayload.total ?? items.length);
+  const page = Number(apiPayload.page || 1);
+  const limit = Number(apiPayload.limit || items.length || 1);
+  const totalPages = limit > 0 ? Math.ceil(total / limit) : 0;
+
+  return {
+    buildings: toBuildingListViewModel(items),
+    pagination: {
+      page,
+      total,
+      limit,
+      totalPages,
+      hasPrev: page > 1,
+      hasNext: page < totalPages,
+      prevPage: page - 1,
+      nextPage: page + 1
+    }
+  };
+}
+
+export function toAdminBuildingFormViewModel(building = {}) {
+  const viewModel = toBuildingViewModel(building);
+
+  return {
+    ...viewModel,
+    owner: viewModel.ownerName || ''
+  };
+}
+
+export function toReviewViewModel(review = {}) {
+  const user = review.user && typeof review.user === 'object' ? review.user : {};
+  const building = review.building && typeof review.building === 'object' ? review.building : {};
+  const status = toDisplayString(review.status || 'published');
+  const moderationStatus = toDisplayString(review.moderationStatus);
+  const author =
+    review.author ||
+    getFullName({
+      firstName: review.firstName || user.firstName,
+      lastName: review.lastName || user.lastName,
+      name: user.name,
+      username: review.username || user.username
+    }) ||
+    'Anonymous';
+  const buildingAddress =
+    review.buildingAddress ||
+    building.streetAddress ||
+    building.address ||
+    review.streetAddress ||
+    '';
+
+  return {
+    ...review,
+    _id: toIdString(review._id || review.id),
+    buildingId: toIdString(review.buildingId || building._id || building.id),
+    userId: toIdString(review.userId || user._id || user.id),
+    author,
+    buildingAddress,
+    text: review.reviewText || review.text || '',
+    reviewText: review.reviewText || review.text || '',
+    rating: Number(review.rating || 0),
+    issueTags: asArray(review.issueTags),
+    status,
+    moderationStatus,
+    isDeleted: review.isDeleted === true || status === 'deleted' || moderationStatus === 'deleted',
+    isHidden: review.isHidden === true || status === 'hidden' || moderationStatus === 'hidden',
+    isFlagged: review.isFlagged === true || moderationStatus === 'flagged'
+  };
+}
+
+export const toReviewListViewModel = (reviews = []) =>
+  asArray(reviews).map(toReviewViewModel);
+
+export const toAdminReviewListViewModel = toReviewListViewModel;
+
+export function toUserViewModel(user = {}) {
+  const role = toDisplayString(user.role || (user.isAdmin ? 'admin' : 'user'), 'user');
+
+  return {
+    ...user,
+    _id: toIdString(user._id || user.id),
+    role,
+    isAdmin: user.isAdmin === true || role === 'admin',
+    isBanned: user.isBanned === true,
+    displayName: getFullName(user) || toDisplayString(user.email)
+  };
+}
+
+export const toUserListViewModel = (users = []) =>
+  asArray(users).map(toUserViewModel);
+
+export const toAdminUserListViewModel = toUserListViewModel;
+
+export function toShortlistItemViewModel(item = {}, building) {
+  const buildingId = toIdString(item.buildingId || item._id || item.id);
+  const buildingViewModel = building
+    ? toBuildingViewModel(building)
+    : { _id: buildingId, address: 'Unknown building', borough: '' };
+
+  return {
+    ...item,
+    _id: buildingId,
+    buildingId,
+    building: buildingViewModel,
+    privateNote: item.privateNote || item.note || ''
+  };
+}
+
+export function toShortlistViewModel(shortlist = {}) {
+  const name = shortlist.shortlistName || shortlist.name || '';
+
+  return {
+    ...shortlist,
+    _id: toIdString(shortlist._id || shortlist.id),
+    name,
+    shortlistName: shortlist.shortlistName || name,
+    items: asArray(shortlist.items).map((item) => toShortlistItemViewModel(item))
+  };
+}
+
+export const toShortlistListViewModel = (shortlists = []) =>
+  asArray(shortlists).map(toShortlistViewModel);
+
+export function toShortlistDetailViewModel(shortlist = {}, items = []) {
+  return {
+    ...toShortlistViewModel(shortlist),
+    items
+  };
+}
+
+export function toPortfolioViewModel(ownerName, buildings = []) {
+  const mappedBuildings = toBuildingListViewModel(buildings);
+
+  return {
+    portfolio: {
+      name: ownerName,
+      buildingCount: mappedBuildings.length
+    },
+    buildings: mappedBuildings
+  };
+}

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,4 +1,10 @@
 import { Router } from 'express';
+import {
+  toAdminBuildingFormViewModel,
+  toAdminReviewListViewModel,
+  toAdminUserListViewModel,
+  toBuildingListViewModel
+} from '../adapters/view-models.js';
 import { requireAdmin } from '../middleware/auth.js';
 import * as api from '../services/api.js';
 
@@ -26,9 +32,7 @@ router.get('/admin/buildings', async (req, res) => {
   try {
     const cookie = req.session.backendCookie;
     const result = await api.buildings.list({ limit: 100 });
-    const buildings = result.ok
-      ? (result.data.items || []).map(b => ({ ...b, address: b.streetAddress || b.address || '' }))
-      : [];
+    const buildings = result.ok ? toBuildingListViewModel(result.data.items || []) : [];
 
     return res.render('admin/buildings/index', {
       pageTitle: 'Manage Buildings — LeaseWise NYC',
@@ -61,9 +65,7 @@ router.get('/admin/buildings/:id/edit', async (req, res) => {
       return res.status(404).render('errors/404', { pageTitle: 'Not Found — LeaseWise NYC' });
     }
 
-    const building = result.data;
-    building.address = building.streetAddress || building.address || '';
-    building.owner = building.ownerName || '';
+    const building = toAdminBuildingFormViewModel(result.data);
 
     return res.render('admin/buildings/form', {
       pageTitle: 'Edit Building — LeaseWise NYC',
@@ -146,7 +148,7 @@ router.get('/admin/users', async (req, res) => {
     const flashError = req.session.flashError;
     delete req.session.flashError;
 
-    const users = result.ok ? result.data || [] : [];
+    const users = result.ok ? toAdminUserListViewModel(result.data) : [];
     const errors = flashError
       ? [{ message: flashError }]
       : result.ok
@@ -202,7 +204,7 @@ router.get('/admin/reviews', async (req, res) => {
     const flashError = req.session.flashError;
     delete req.session.flashError;
 
-    const reviews = result.ok ? result.data || [] : [];
+    const reviews = result.ok ? toAdminReviewListViewModel(result.data) : [];
     const errors = flashError
       ? [{ message: flashError }]
       : result.ok

--- a/routes/site.js
+++ b/routes/site.js
@@ -1,4 +1,11 @@
 import { Router } from "express";
+import {
+  toBuildingSearchViewModel,
+  toBuildingViewModel,
+  toPortfolioViewModel,
+  toReviewListViewModel,
+  toShortlistListViewModel
+} from "../adapters/view-models.js";
 import * as api from "../services/api.js";
 import {
   getUserFriendlyApiError,
@@ -37,16 +44,7 @@ router.get("/buildings", async (req, res) => {
       });
     }
 
-    const { items, total, page: currentPage, limit } = result.data;
-    const totalPages = Math.ceil(total / limit);
-    const pagination = {
-      page: currentPage,
-      totalPages,
-      hasPrev: currentPage > 1,
-      hasNext: currentPage < totalPages,
-      prevPage: currentPage - 1,
-      nextPage: currentPage + 1,
-    };
+    const { buildings, pagination } = toBuildingSearchViewModel(result.data);
 
     let watchlistIds = [];
     if (req.session.user && req.session.backendCookie) {
@@ -55,7 +53,7 @@ router.get("/buildings", async (req, res) => {
 
     return res.render("buildings/index", {
       pageTitle: "Browse Buildings — LeaseWise NYC",
-      buildings: items,
+      buildings,
       pagination,
       watchlistIds,
       scripts: SCRIPTS,
@@ -84,27 +82,8 @@ router.get("/buildings/:id", async (req, res) => {
       });
     }
 
-    const building = buildingResult.data;
-    building.address = building.streetAddress || building.address || "";
-
-    if (building.ownerName) {
-      building.owner = {
-        name: building.ownerName,
-        _id: encodeURIComponent(building.ownerName),
-      };
-    }
-
-    const reviews = (reviewsResult.ok ? reviewsResult.data : []).map((r) => ({
-      ...r,
-      _id: r._id,
-      author: r.firstName
-        ? `${r.firstName} ${r.lastName || ""}`.trim()
-        : "Anonymous",
-      text: r.reviewText || r.text || "",
-      rating: r.rating || 0,
-      issueTags: r.issueTags || [],
-      createdAt: r.createdAt,
-    }));
+    const building = toBuildingViewModel(buildingResult.data);
+    const reviews = toReviewListViewModel(reviewsResult.ok ? reviewsResult.data : []);
 
     let isWatched = false;
     let userShortlists = [];
@@ -117,10 +96,7 @@ router.get("/buildings/:id", async (req, res) => {
 
       const slResult = await api.shortlists.list(cookie);
       if (slResult.ok) {
-        userShortlists = (slResult.data || []).map((sl) => ({
-          _id: sl._id,
-          name: sl.shortlistName || sl.name || "",
-        }));
+        userShortlists = toShortlistListViewModel(slResult.data);
       }
     }
 
@@ -154,16 +130,15 @@ router.get("/portfolios/:ownerName", async (req, res) => {
     const ownerName = decodeURIComponent(req.params.ownerName);
     const result = await api.buildings.getByOwner(ownerName);
 
-    const buildingsList = result.ok ? result.data || [] : [];
-    const mappedBuildings = buildingsList.map((b) => ({
-      ...b,
-      address: b.streetAddress || b.address || "",
-    }));
+    const { portfolio, buildings } = toPortfolioViewModel(
+      ownerName,
+      result.ok ? result.data || [] : []
+    );
 
     return res.render("portfolios/detail", {
       pageTitle: `${ownerName} Portfolio — LeaseWise NYC`,
-      portfolio: { name: ownerName, buildingCount: mappedBuildings.length },
-      buildings: mappedBuildings,
+      portfolio,
+      buildings,
       scripts: SCRIPTS,
     });
   } catch {

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,4 +1,10 @@
 import { Router } from 'express';
+import {
+  toBuildingListViewModel,
+  toShortlistDetailViewModel,
+  toShortlistItemViewModel,
+  toShortlistListViewModel
+} from '../adapters/view-models.js';
 import { requireAuth } from '../middleware/auth.js';
 import * as api from '../services/api.js';
 
@@ -89,9 +95,7 @@ router.get('/watchlist', async (req, res) => {
 
     const buildingPromises = watchlistIds.map(id => api.buildings.getById(id));
     const results = await Promise.all(buildingPromises);
-    const buildings = results
-      .filter(r => r.ok)
-      .map(r => ({ ...r.data, address: r.data.streetAddress || r.data.address || '' }));
+    const buildings = toBuildingListViewModel(results.filter(r => r.ok).map(r => r.data));
 
     return res.render('watchlist', {
       pageTitle: 'My Watchlist — LeaseWise NYC',
@@ -111,13 +115,7 @@ router.get('/shortlists', async (req, res) => {
   try {
     const cookie = req.session.backendCookie;
     const result = await api.shortlists.list(cookie);
-    const shortlists = result.ok
-      ? (result.data || []).map(sl => ({
-          _id: sl._id,
-          name: sl.shortlistName || sl.name || '',
-          items: sl.items || []
-        }))
-      : [];
+    const shortlists = result.ok ? toShortlistListViewModel(result.data) : [];
 
     return res.render('shortlists/index', {
       pageTitle: 'My Shortlists — LeaseWise NYC',
@@ -141,7 +139,8 @@ router.get('/shortlists/:id', async (req, res) => {
       return res.status(404).render('errors/404', { pageTitle: 'Not Found — LeaseWise NYC' });
     }
 
-    const shortlist = (result.data || []).find(sl => String(sl._id) === req.params.id);
+    const shortlist = toShortlistListViewModel(result.data || [])
+      .find(sl => String(sl._id) === req.params.id);
     if (!shortlist) {
       return res.status(404).render('errors/404', { pageTitle: 'Not Found — LeaseWise NYC' });
     }
@@ -150,23 +149,17 @@ router.get('/shortlists/:id', async (req, res) => {
       (shortlist.items || []).map(async (item) => {
         const bid = item.buildingId || item._id;
         const bResult = await api.buildings.getById(bid);
-        return {
-          _id: bid,
-          building: bResult.ok
-            ? { ...bResult.data, address: bResult.data.streetAddress || bResult.data.address || '' }
-            : { _id: bid, address: 'Unknown building', borough: '' },
-          privateNote: item.privateNote || ''
-        };
+        return toShortlistItemViewModel(
+          item,
+          bResult.ok ? bResult.data : { _id: bid, address: 'Unknown building', borough: '' }
+        );
       })
     );
+    const shortlistViewModel = toShortlistDetailViewModel(shortlist, items);
 
     return res.render('shortlists/detail', {
-      pageTitle: `${shortlist.shortlistName || shortlist.name || 'Shortlist'} — LeaseWise NYC`,
-      shortlist: {
-        _id: shortlist._id,
-        name: shortlist.shortlistName || shortlist.name || '',
-        items
-      },
+      pageTitle: `${shortlistViewModel.name || 'Shortlist'} — LeaseWise NYC`,
+      shortlist: shortlistViewModel,
       scripts: SCRIPTS
     });
   } catch {
@@ -203,9 +196,7 @@ router.get('/compare', async (req, res) => {
     const buildingResults = await Promise.all(
       (shortlist.items || []).map(item => api.buildings.getById(item.buildingId || item._id))
     );
-    const buildings = buildingResults
-      .filter(r => r.ok)
-      .map(r => ({ ...r.data, address: r.data.streetAddress || r.data.address || '' }));
+    const buildings = toBuildingListViewModel(buildingResults.filter(r => r.ok).map(r => r.data));
 
     return res.render('compare', {
       pageTitle: 'Compare Buildings — LeaseWise NYC',


### PR DESCRIPTION
## Summary

Implemented front-end issue #30: API response adapters for view models.

## What Changed

- Added reusable view-model adapter functions in `adapters/view-models.js`.
- Added building response adapters for:
  - building cards
  - building detail pages
  - building search results
  - portfolio building lists
  - admin building forms
- Added review response adapters for:
  - public review display
  - admin review moderation rows
  - moderation status flags
- Added user response adapters for admin user management rows.
- Added shortlist response adapters for:
  - shortlist list pages
  - shortlist detail pages
  - shortlist item rows with building data
- Replaced repeated inline mapping logic in route handlers with shared adapter calls.
- Kept the existing placeholder page adapter export intact.

## Behavior Impact

Route handlers now use shared adapters to convert backend API responses into view-friendly data shapes. This reduces duplicated mapping logic and gives pages consistent fields such as `address`, `owner`, `author`, `name`, `isAdmin`, `isHidden`, and `isFlagged`.

## Files Changed

- `adapters/view-models.js`
- `routes/site.js`
- `routes/user.js`
- `routes/admin.js`

## Testing

- Passed `node --check adapters/view-models.js`.
- Passed `node --check routes/site.js`.
- Passed `node --check routes/user.js`.
- Passed `node --check routes/admin.js`.
- Passed `git diff --check`.
- Ran adapter behavior tests covering:
  - building address normalization
  - owner view model creation
  - risk summary normalization
  - building search pagination view model creation
  - admin building form fields
  - review author and text normalization
  - review moderation status flags
  - admin user role and banned status flags
  - shortlist name and item normalization
  - shortlist detail item building mapping
  - portfolio view model creation
- Started frontend with `PORT=4334 npm start`.
- Verified `GET /api/status` returns a healthy response.
- Stopped the local frontend test server.

## Notes

This PR only covers issue #30. It does not include CSRF protection, authentication flow changes, or shortlist note editing work.
