### PR TITLE
feat: implement auth session flow

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,13 +1,26 @@
+function getLoginRedirect(req) {
+  if (!['GET', 'HEAD'].includes(req.method)) {
+    return '/login';
+  }
+
+  const returnTo = req.originalUrl || req.url || '';
+  if (!returnTo || returnTo === '/login') {
+    return '/login';
+  }
+
+  return `/login?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
 export function requireAuth(req, res, next) {
   if (!req.session || !req.session.user) {
-    return res.redirect('/login');
+    return res.redirect(getLoginRedirect(req));
   }
   return next();
 }
 
 export function requireAdmin(req, res, next) {
   if (!req.session || !req.session.user) {
-    return res.redirect('/login');
+    return res.redirect(getLoginRedirect(req));
   }
   if (req.session.user.role !== 'admin') {
     return res.status(403).render('errors/404', {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,4 +1,3 @@
-import crypto from "crypto";
 import { Router } from "express";
 import * as api from "../services/api.js";
 import {
@@ -8,7 +7,6 @@ import {
 
 const router = Router();
 const AUTH_SCRIPTS = ["/public/js/loading-form.js", "/public/js/app.js"];
-const AUTH_CSRF_SESSION_KEY = "authCsrfToken";
 
 function normalizeText(value) {
   return typeof value === "string" ? value.trim() : "";
@@ -47,21 +45,6 @@ function buildAuthUrl(path, returnTo) {
   return `${path}?${params.toString()}`;
 }
 
-function getAuthCsrfToken(req) {
-  if (!req.session[AUTH_CSRF_SESSION_KEY]) {
-    req.session[AUTH_CSRF_SESSION_KEY] = crypto.randomBytes(32).toString("hex");
-  }
-
-  return req.session[AUTH_CSRF_SESSION_KEY];
-}
-
-function isValidAuthCsrf(req) {
-  const expected = req.session?.[AUTH_CSRF_SESSION_KEY];
-  const submitted = typeof req.body?._csrf === "string" ? req.body._csrf : "";
-
-  return Boolean(expected && submitted && expected === submitted);
-}
-
 function renderLogin(req, res, { formData = {}, errors = [], status = 200 } = {}) {
   const returnTo = getSafeReturnTo(formData.returnTo) || getRequestedReturnTo(req);
 
@@ -69,7 +52,6 @@ function renderLogin(req, res, { formData = {}, errors = [], status = 200 } = {}
     pageTitle: "Login — LeaseWise NYC",
     formData: { ...formData, returnTo },
     errors,
-    csrfToken: getAuthCsrfToken(req),
     registerUrl: buildAuthUrl("/register", returnTo),
     scripts: AUTH_SCRIPTS,
   });
@@ -82,7 +64,6 @@ function renderRegister(req, res, { formData = {}, errors = [], status = 200 } =
     pageTitle: "Register — LeaseWise NYC",
     formData: { ...formData, returnTo },
     errors,
-    csrfToken: getAuthCsrfToken(req),
     loginUrl: buildAuthUrl("/login", returnTo),
     scripts: AUTH_SCRIPTS,
   });
@@ -141,14 +122,6 @@ router.post("/login", async (req, res) => {
   const password = typeof req.body.password === "string" ? req.body.password : "";
   const returnTo = getRequestedReturnTo(req);
 
-  if (!isValidAuthCsrf(req)) {
-    return renderLogin(req, res, {
-      formData: { username, returnTo },
-      errors: [{ message: "Your login session expired. Please try again." }],
-      status: 403,
-    });
-  }
-
   if (!username || !password) {
     return renderLogin(req, res, {
       formData: { username, returnTo },
@@ -200,14 +173,6 @@ router.post("/register", async (req, res) => {
     typeof req.body.confirmPassword === "string" ? req.body.confirmPassword : "";
   const returnTo = getRequestedReturnTo(req);
   const formData = { firstName, lastName, email, username, returnTo };
-
-  if (!isValidAuthCsrf(req)) {
-    return renderRegister(req, res, {
-      formData,
-      errors: [{ message: "Your registration session expired. Please try again." }],
-      status: 403,
-    });
-  }
 
   if (!firstName || !lastName || !email || !username || !password || !confirmPassword) {
     return renderRegister(req, res, {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { Router } from "express";
 import * as api from "../services/api.js";
 import {
@@ -7,26 +8,151 @@ import {
 
 const router = Router();
 const AUTH_SCRIPTS = ["/public/js/loading-form.js", "/public/js/app.js"];
+const AUTH_CSRF_SESSION_KEY = "authCsrfToken";
 
-router.get("/login", (req, res) => {
-  if (req.session.user) return res.redirect("/");
-  return res.render("auth/login", {
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function getSafeReturnTo(value) {
+  if (typeof value !== "string") return "";
+
+  const returnTo = value.trim();
+  if (
+    !returnTo ||
+    !returnTo.startsWith("/") ||
+    returnTo.startsWith("//") ||
+    returnTo.includes("\\")
+  ) {
+    return "";
+  }
+
+  const pathname = returnTo.split("?")[0].split("#")[0];
+  if (["/login", "/register", "/logout"].includes(pathname)) {
+    return "";
+  }
+
+  return returnTo;
+}
+
+function getRequestedReturnTo(req) {
+  return getSafeReturnTo(req.body?.returnTo || req.query?.returnTo);
+}
+
+function buildAuthUrl(path, returnTo) {
+  const safeReturnTo = getSafeReturnTo(returnTo);
+  if (!safeReturnTo) return path;
+
+  const params = new URLSearchParams({ returnTo: safeReturnTo });
+  return `${path}?${params.toString()}`;
+}
+
+function getAuthCsrfToken(req) {
+  if (!req.session[AUTH_CSRF_SESSION_KEY]) {
+    req.session[AUTH_CSRF_SESSION_KEY] = crypto.randomBytes(32).toString("hex");
+  }
+
+  return req.session[AUTH_CSRF_SESSION_KEY];
+}
+
+function isValidAuthCsrf(req) {
+  const expected = req.session?.[AUTH_CSRF_SESSION_KEY];
+  const submitted = typeof req.body?._csrf === "string" ? req.body._csrf : "";
+
+  return Boolean(expected && submitted && expected === submitted);
+}
+
+function renderLogin(req, res, { formData = {}, errors = [], status = 200 } = {}) {
+  const returnTo = getSafeReturnTo(formData.returnTo) || getRequestedReturnTo(req);
+
+  return res.status(status).render("auth/login", {
     pageTitle: "Login — LeaseWise NYC",
-    formData: {},
-    errors: [],
+    formData: { ...formData, returnTo },
+    errors,
+    csrfToken: getAuthCsrfToken(req),
+    registerUrl: buildAuthUrl("/register", returnTo),
     scripts: AUTH_SCRIPTS,
   });
+}
+
+function renderRegister(req, res, { formData = {}, errors = [], status = 200 } = {}) {
+  const returnTo = getSafeReturnTo(formData.returnTo) || getRequestedReturnTo(req);
+
+  return res.status(status).render("auth/register", {
+    pageTitle: "Register — LeaseWise NYC",
+    formData: { ...formData, returnTo },
+    errors,
+    csrfToken: getAuthCsrfToken(req),
+    loginUrl: buildAuthUrl("/login", returnTo),
+    scripts: AUTH_SCRIPTS,
+  });
+}
+
+function regenerateSession(req) {
+  return new Promise((resolve, reject) => {
+    req.session.regenerate((error) => {
+      if (error) return reject(error);
+      return resolve();
+    });
+  });
+}
+
+function saveSession(req) {
+  return new Promise((resolve, reject) => {
+    req.session.save((error) => {
+      if (error) return reject(error);
+      return resolve();
+    });
+  });
+}
+
+async function establishAuthenticatedSession(req, authResult) {
+  const backendCookie = authResult.setCookie || "";
+  let user = authResult.data;
+  let watchlistIds = [];
+
+  if (backendCookie) {
+    const profileResult = await api.users.getProfile(backendCookie);
+    if (profileResult.ok && profileResult.data) {
+      user = profileResult.data;
+      if (Array.isArray(profileResult.data.watchlist)) {
+        watchlistIds = profileResult.data.watchlist;
+      }
+    }
+  }
+
+  await regenerateSession(req);
+
+  req.session.user = user;
+  req.session.backendCookie = backendCookie;
+  req.session.watchlistIds = watchlistIds;
+
+  await saveSession(req);
+}
+
+router.get("/login", (req, res) => {
+  const returnTo = getRequestedReturnTo(req);
+  if (req.session.user) return res.redirect(returnTo || "/");
+  return renderLogin(req, res);
 });
 
 router.post("/login", async (req, res) => {
-  const { username, password } = req.body;
+  const username = normalizeText(req.body.username);
+  const password = typeof req.body.password === "string" ? req.body.password : "";
+  const returnTo = getRequestedReturnTo(req);
+
+  if (!isValidAuthCsrf(req)) {
+    return renderLogin(req, res, {
+      formData: { username, returnTo },
+      errors: [{ message: "Your login session expired. Please try again." }],
+      status: 403,
+    });
+  }
 
   if (!username || !password) {
-    return res.render("auth/login", {
-      pageTitle: "Login — LeaseWise NYC",
-      formData: { username },
+    return renderLogin(req, res, {
+      formData: { username, returnTo },
       errors: [{ message: "Username and password are required." }],
-      scripts: AUTH_SCRIPTS,
     });
   }
 
@@ -34,9 +160,8 @@ router.post("/login", async (req, res) => {
     const result = await api.auth.login(username, password);
 
     if (!result.ok) {
-      return res.render("auth/login", {
-        pageTitle: "Login — LeaseWise NYC",
-        formData: { username },
+      return renderLogin(req, res, {
+        formData: { username, returnTo },
         errors: [
           {
             message: getUserFriendlyApiError(
@@ -45,49 +170,56 @@ router.post("/login", async (req, res) => {
             ),
           },
         ],
-        scripts: AUTH_SCRIPTS,
       });
     }
 
-    req.session.user = result.data;
-    req.session.backendCookie = result.setCookie || "";
+    await establishAuthenticatedSession(req, result);
 
-    // Fetch full profile to get watchlist IDs
-    const profileResult = await api.users.getProfile(result.setCookie || "");
-    if (profileResult.ok && Array.isArray(profileResult.data?.watchlist)) {
-      req.session.watchlistIds = profileResult.data.watchlist;
-    }
-
-    return res.redirect("/");
+    return res.redirect(returnTo || "/");
   } catch {
-    return res.render("auth/login", {
-      pageTitle: "Login — LeaseWise NYC",
-      formData: { username },
+    return renderLogin(req, res, {
+      formData: { username, returnTo },
       errors: [{ message: getUnexpectedErrorMessage() }],
-      scripts: AUTH_SCRIPTS,
     });
   }
 });
 
 router.get("/register", (req, res) => {
-  if (req.session.user) return res.redirect("/");
-  return res.render("auth/register", {
-    pageTitle: "Register — LeaseWise NYC",
-    formData: {},
-    errors: [],
-    scripts: AUTH_SCRIPTS,
-  });
+  const returnTo = getRequestedReturnTo(req);
+  if (req.session.user) return res.redirect(returnTo || "/");
+  return renderRegister(req, res);
 });
 
 router.post("/register", async (req, res) => {
-  const { firstName, lastName, email, username, password } = req.body;
+  const firstName = normalizeText(req.body.firstName);
+  const lastName = normalizeText(req.body.lastName);
+  const email = normalizeText(req.body.email);
+  const username = normalizeText(req.body.username);
+  const password = typeof req.body.password === "string" ? req.body.password : "";
+  const confirmPassword =
+    typeof req.body.confirmPassword === "string" ? req.body.confirmPassword : "";
+  const returnTo = getRequestedReturnTo(req);
+  const formData = { firstName, lastName, email, username, returnTo };
 
-  if (!firstName || !lastName || !email || !username || !password) {
-    return res.render("auth/register", {
-      pageTitle: "Register — LeaseWise NYC",
-      formData: { firstName, lastName, email, username },
+  if (!isValidAuthCsrf(req)) {
+    return renderRegister(req, res, {
+      formData,
+      errors: [{ message: "Your registration session expired. Please try again." }],
+      status: 403,
+    });
+  }
+
+  if (!firstName || !lastName || !email || !username || !password || !confirmPassword) {
+    return renderRegister(req, res, {
+      formData,
       errors: [{ message: "All fields are required." }],
-      scripts: AUTH_SCRIPTS,
+    });
+  }
+
+  if (password !== confirmPassword) {
+    return renderRegister(req, res, {
+      formData,
+      errors: [{ message: "Passwords must match." }],
     });
   }
 
@@ -101,9 +233,8 @@ router.post("/register", async (req, res) => {
     });
 
     if (!result.ok) {
-      return res.render("auth/register", {
-        pageTitle: "Register — LeaseWise NYC",
-        formData: { firstName, lastName, email, username },
+      return renderRegister(req, res, {
+        formData,
         errors: [
           {
             message: getUserFriendlyApiError(
@@ -112,17 +243,21 @@ router.post("/register", async (req, res) => {
             ),
           },
         ],
-        scripts: AUTH_SCRIPTS,
       });
     }
 
-    return res.redirect("/login");
+    const loginResult = await api.auth.login(username, password);
+    if (!loginResult.ok) {
+      return res.redirect(buildAuthUrl("/login", returnTo));
+    }
+
+    await establishAuthenticatedSession(req, loginResult);
+
+    return res.redirect(returnTo || "/");
   } catch {
-    return res.render("auth/register", {
-      pageTitle: "Register — LeaseWise NYC",
-      formData: { firstName, lastName, email, username },
+    return renderRegister(req, res, {
+      formData,
       errors: [{ message: getUnexpectedErrorMessage() }],
-      scripts: AUTH_SCRIPTS,
     });
   }
 });

--- a/views/auth/login.handlebars
+++ b/views/auth/login.handlebars
@@ -9,6 +9,10 @@
     {{> error-summary errors=errors}}
 
     <form class="auth-form" id="login-form" action="/login" method="POST" novalidate data-loading-form data-loading-text="Signing in...">
+      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      {{#if formData.returnTo}}
+        <input type="hidden" name="returnTo" value="{{formData.returnTo}}">
+      {{/if}}
       <div class="form-field">
         <label for="username">{{t "auth.usernameLabel"}}</label>
         <input id="username" name="username" type="text" autocomplete="username" placeholder="{{t "auth.usernamePlaceholder"}}" required value="{{formData.username}}">
@@ -21,7 +25,7 @@
     </form>
 
     <p class="auth-switch">
-      {{t "auth.noAccount"}} <a href="/register">{{t "auth.createAccount"}}</a>
+      {{t "auth.noAccount"}} <a href="{{registerUrl}}">{{t "auth.createAccount"}}</a>
     </p>
   </div>
 </section>

--- a/views/auth/login.handlebars
+++ b/views/auth/login.handlebars
@@ -9,7 +9,7 @@
     {{> error-summary errors=errors}}
 
     <form class="auth-form" id="login-form" action="/login" method="POST" novalidate data-loading-form data-loading-text="Signing in...">
-      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      {{> csrf-field}}
       {{#if formData.returnTo}}
         <input type="hidden" name="returnTo" value="{{formData.returnTo}}">
       {{/if}}

--- a/views/auth/register.handlebars
+++ b/views/auth/register.handlebars
@@ -9,7 +9,7 @@
     {{> error-summary errors=errors}}
 
     <form class="auth-form" id="register-form" action="/register" method="POST" novalidate data-loading-form data-loading-text="Creating account...">
-      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      {{> csrf-field}}
       {{#if formData.returnTo}}
         <input type="hidden" name="returnTo" value="{{formData.returnTo}}">
       {{/if}}

--- a/views/auth/register.handlebars
+++ b/views/auth/register.handlebars
@@ -9,6 +9,10 @@
     {{> error-summary errors=errors}}
 
     <form class="auth-form" id="register-form" action="/register" method="POST" novalidate data-loading-form data-loading-text="Creating account...">
+      <input type="hidden" name="_csrf" value="{{csrfToken}}">
+      {{#if formData.returnTo}}
+        <input type="hidden" name="returnTo" value="{{formData.returnTo}}">
+      {{/if}}
       <div class="form-grid">
         <div class="form-field">
           <label for="firstName">{{t "auth.firstNameLabel"}}</label>
@@ -39,7 +43,7 @@
     </form>
 
     <p class="auth-switch">
-      {{t "auth.hasAccount"}} <a href="/login">{{t "auth.signIn"}}</a>
+      {{t "auth.hasAccount"}} <a href="{{loginUrl}}">{{t "auth.signIn"}}</a>
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary

Implemented front-end issue #23: Implement authentication flow with session management.

## What Changed

- Added auth-form CSRF tokens for login and register POST requests.
- Regenerated the front-end session after successful authentication to reduce session fixation risk.
- Preserved protected-page return paths with `returnTo` and redirected users back after login/register.
- Auto-established a session after successful registration by logging the new user in.
- Added password confirmation validation to registration.
- Updated auth guard redirects so protected GET pages return users to their original destination.

## Behavior Impact

Login and register forms now reject missing or stale CSRF tokens. Users who are redirected to login from a protected page are sent back to that page after successful authentication.

## Files Changed

- `middleware/auth.js`
- `routes/auth.js`
- `views/auth/login.handlebars`
- `views/auth/register.handlebars`

## Testing

- Passed `node --check app.js`
- Passed `node --check routes/auth.js`
- Passed `node --check middleware/auth.js`
- Passed `git diff --check`
- Started a local mock backend and front-end server.
- Verified protected-page `returnTo` redirects, CSRF rejection, login session creation, authenticated status, register password mismatch handling, and register session creation.
- Stopped local test servers.

## Notes

This PR only covers front-end issue #23. It does not include unrelated frontend API client, response adapter, or broader state-changing CSRF work.