### PR TITLE
feat: complete shortlist note editing

### DIFF
--- a/locales/en.js
+++ b/locales/en.js
@@ -256,7 +256,14 @@ export default {
     label: 'Private note',
     placeholder: 'Add a private note about this building...',
     hint: 'Only visible to you.',
-    save: 'Save note'
+    save: 'Save note',
+    saving: 'Saving...',
+    edit: 'Edit',
+    cancel: 'Cancel',
+    empty: 'No private note yet.',
+    saved: 'Note saved.',
+    error: 'Unable to save note. Please try again.',
+    tooLong: 'Private note must be 1000 characters or fewer.'
   },
   dialog: {
     cancel: 'Cancel'

--- a/locales/zh-CN.js
+++ b/locales/zh-CN.js
@@ -256,7 +256,14 @@ export default {
     label: '私人备注',
     placeholder: '添加关于此建筑的私人备注...',
     hint: '仅您可见。',
-    save: '保存备注'
+    save: '保存备注',
+    saving: '正在保存...',
+    edit: '编辑',
+    cancel: '取消',
+    empty: '暂无私人备注。',
+    saved: '备注已保存。',
+    error: '无法保存备注，请重试。',
+    tooLong: '私人备注不能超过 1000 个字符。'
   },
   dialog: {
     cancel: '取消'

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -474,6 +474,38 @@ code {
   padding: var(--space-md);
 }
 
+.note-form__header,
+.note-form__view,
+.note-form__meta,
+.note-form__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  justify-content: space-between;
+}
+
+.note-form__preview {
+  color: var(--color-text);
+  margin: 0;
+  min-width: min(18rem, 100%);
+  white-space: pre-wrap;
+}
+
+.note-form__preview.is-empty {
+  color: var(--color-text-soft);
+  font-style: italic;
+}
+
+.note-form__editor {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.note-form [hidden] {
+  display: none;
+}
+
 .note-form textarea {
   border: 1px solid var(--color-border);
   border-radius: var(--token-radius-sm);
@@ -483,6 +515,30 @@ code {
   resize: vertical;
   width: 100%;
   box-sizing: border-box;
+}
+
+.note-form textarea[aria-invalid="true"] {
+  border-color: var(--color-danger);
+}
+
+.note-form__status {
+  color: var(--color-success);
+  font-weight: 700;
+}
+
+.note-form__counter {
+  color: var(--color-text-soft);
+  font-size: 0.9rem;
+}
+
+.note-form__counter.is-over-limit,
+.form-error {
+  color: var(--color-danger);
+}
+
+.form-error {
+  font-weight: 700;
+  margin: 0;
 }
 
 .error-summary {

--- a/public/js/shortlist-note.js
+++ b/public/js/shortlist-note.js
@@ -1,38 +1,221 @@
 (function () {
-  document.addEventListener('submit', async (e) => {
-    const form = e.target.closest('.note-form');
-    if (!form) return;
+  const DEFAULT_MAX_LENGTH = 1000;
 
-    e.preventDefault();
+  function getFormParts(form) {
+    return {
+      view: form.querySelector('[data-note-view]'),
+      editor: form.querySelector('[data-note-editor]'),
+      input: form.querySelector('[data-note-input]'),
+      preview: form.querySelector('[data-note-preview]'),
+      counter: form.querySelector('[data-note-counter]'),
+      error: form.querySelector('[data-ajax-error]'),
+      success: form.querySelector('[data-ajax-success]'),
+      editButton: form.querySelector('[data-note-edit]')
+    };
+  }
 
+  function getMaxLength(form) {
+    const maxLength = Number(form.dataset.noteMaxLength);
+    return Number.isInteger(maxLength) && maxLength > 0 ? maxLength : DEFAULT_MAX_LENGTH;
+  }
+
+  function getNoteValue(form) {
+    return getFormParts(form).input?.value || '';
+  }
+
+  function setMessage(element, message) {
+    if (!element) return;
+    element.textContent = message || '';
+    element.hidden = !message;
+  }
+
+  function clearFeedback(form) {
+    const { error, success, input } = getFormParts(form);
+    setMessage(error, '');
+    setMessage(success, '');
+    input?.removeAttribute('aria-invalid');
+  }
+
+  function updateCounter(form) {
+    const { counter } = getFormParts(form);
+    if (!counter) return;
+
+    const maxLength = getMaxLength(form);
+    const length = getNoteValue(form).length;
+    counter.textContent = `${length} / ${maxLength}`;
+    counter.classList.toggle('is-over-limit', length > maxLength);
+  }
+
+  function updatePreview(form, note) {
+    const { preview } = getFormParts(form);
+    if (!preview) return;
+
+    const displayText = note.trim();
+    preview.textContent = displayText || preview.dataset.emptyText || '';
+    preview.classList.toggle('is-empty', !displayText);
+  }
+
+  function setEditorVisible(form, isVisible, { focus = false } = {}) {
+    const { view, editor, input } = getFormParts(form);
+
+    if (view) view.hidden = isVisible;
+    if (editor) editor.hidden = !isVisible;
+
+    if (isVisible) {
+      updateCounter(form);
+      if (focus) input?.focus();
+    }
+  }
+
+  function resetEditor(form) {
+    const { input } = getFormParts(form);
+    if (!input) return;
+
+    input.value = form.dataset.savedNote || '';
+    clearFeedback(form);
+    updateCounter(form);
+  }
+
+  function getValidationError(form) {
+    const note = getNoteValue(form);
+    const maxLength = getMaxLength(form);
+
+    if (note.length > maxLength) {
+      return form.dataset.noteTooLongMessage || `Private note must be ${maxLength} characters or fewer.`;
+    }
+
+    return '';
+  }
+
+  function renderValidationError(form, message) {
+    const { error, input } = getFormParts(form);
+    setMessage(error, message);
+
+    if (message) {
+      input?.setAttribute('aria-invalid', 'true');
+    } else {
+      input?.removeAttribute('aria-invalid');
+    }
+  }
+
+  function getApiUrl(form) {
     const action = form.getAttribute('action') || '';
     const match = action.match(/\/shortlists\/([^/]+)\/items\/([^/]+)\/note/);
-    if (!match) return;
 
-    const [, shortlistId, buildingId] = match;
-    const formData = new FormData(form);
-    const note = formData.get('note') || '';
-
-    const submitBtn = form.querySelector('button[type="submit"]');
-    if (submitBtn) submitBtn.disabled = true;
-
-    try {
-      const res = await fetch(`/api/shortlists/${shortlistId}/items/${buildingId}/note`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ privateNote: note })
-      });
-      const data = await res.json();
-
-      if (data.success && submitBtn) {
-        const original = submitBtn.textContent;
-        submitBtn.textContent = 'Saved!';
-        setTimeout(() => { submitBtn.textContent = original; }, 2000);
-      }
-    } catch {
-      form.submit();
-    } finally {
-      if (submitBtn) submitBtn.disabled = false;
+    if (!match) {
+      return '';
     }
-  });
+
+    return `/api/shortlists/${encodeURIComponent(match[1])}/items/${encodeURIComponent(match[2])}/note`;
+  }
+
+  async function fallbackSubmit(form, apiUrl, privateNote) {
+    try {
+      const response = await fetch(apiUrl, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ privateNote })
+      });
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok || payload?.success === false) {
+        return {
+          success: false,
+          error: payload?.error || form.dataset.noteErrorMessage || 'Unable to save note.'
+        };
+      }
+
+      return { success: true, data: payload?.data || { privateNote } };
+    } catch {
+      return {
+        success: false,
+        error: form.dataset.noteErrorMessage || 'Unable to save note.'
+      };
+    }
+  }
+
+  async function submitNote(form) {
+    const apiUrl = getApiUrl(form);
+    const privateNote = getNoteValue(form);
+    const validationError = getValidationError(form);
+
+    clearFeedback(form);
+
+    if (!apiUrl) {
+      form.submit();
+      return;
+    }
+
+    if (validationError) {
+      renderValidationError(form, validationError);
+      return;
+    }
+
+    const ajax = window.LeaseWiseAjaxForms;
+    const result = ajax?.submitAjaxForm
+      ? await ajax.submitAjaxForm(form, {
+          url: apiUrl,
+          method: 'POST',
+          loadingText: form.dataset.loadingText || 'Saving...',
+          getPayload: () => ({ privateNote })
+        })
+      : await fallbackSubmit(form, apiUrl, privateNote);
+
+    if (!result.success) {
+      renderValidationError(form, result.error || form.dataset.noteErrorMessage || 'Unable to save note.');
+      return;
+    }
+
+    const savedNote = result.data?.privateNote ?? privateNote;
+    form.dataset.savedNote = savedNote;
+    getFormParts(form).input.value = savedNote;
+    updatePreview(form, savedNote);
+    setMessage(getFormParts(form).success, form.dataset.noteSavedMessage || result.message || 'Note saved.');
+    setEditorVisible(form, false);
+  }
+
+  function initNoteForm(form) {
+    const { input, editButton } = getFormParts(form);
+
+    form.dataset.savedNote = input?.value || '';
+    updatePreview(form, form.dataset.savedNote);
+    updateCounter(form);
+    setEditorVisible(form, false);
+
+    editButton?.addEventListener('click', () => {
+      clearFeedback(form);
+      setEditorVisible(form, true, { focus: true });
+    });
+
+    form.querySelector('[data-note-cancel]')?.addEventListener('click', () => {
+      resetEditor(form);
+      setEditorVisible(form, false);
+    });
+
+    input?.addEventListener('input', () => {
+      updateCounter(form);
+      if (!getValidationError(form)) {
+        renderValidationError(form, '');
+      }
+    });
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      submitNote(form);
+    });
+  }
+
+  function init() {
+    document.querySelectorAll('[data-note-form]').forEach(initNoteForm);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
 })();

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import * as api from '../services/api.js';
+import { shortlistNoteValidationSchema, validateForm } from '../utils/validation.js';
 
 const router = Router();
 
@@ -49,10 +50,24 @@ router.post('/api/buildings/:id/review', requireAuth, async (req, res) => {
 router.post('/api/shortlists/:shortlistId/items/:buildingId/note', requireAuth, async (req, res) => {
   try {
     const cookie = req.session.backendCookie;
+    const validation = validateForm(
+      { privateNote: req.body.privateNote ?? req.body.note ?? '' },
+      shortlistNoteValidationSchema
+    );
+
+    if (!validation.isValid) {
+      const message = validation.errors.privateNote?.message || 'Private note is invalid.';
+      return res.status(400).json({
+        success: false,
+        error: message,
+        fieldErrors: { privateNote: message }
+      });
+    }
+
     const result = await api.shortlists.updateNote(
       req.params.shortlistId,
       req.params.buildingId,
-      req.body.note || req.body.privateNote || '',
+      validation.values.privateNote,
       cookie
     );
 
@@ -60,7 +75,11 @@ router.post('/api/shortlists/:shortlistId/items/:buildingId/note', requireAuth, 
       return res.status(result.status || 400).json({ success: false, error: result.error });
     }
 
-    return res.json({ success: true });
+    return res.json({
+      success: true,
+      message: 'Note saved.',
+      data: { privateNote: validation.values.privateNote }
+    });
   } catch {
     return res.status(500).json({ success: false, error: 'Internal server error' });
   }

--- a/routes/user.js
+++ b/routes/user.js
@@ -4,7 +4,7 @@ import * as api from '../services/api.js';
 
 const router = Router();
 
-const SCRIPTS = ['/public/js/dialog.js', '/public/js/watchlist.js', '/public/js/shortlist-note.js', '/public/js/app.js'];
+const SCRIPTS = ['/public/js/dialog.js', '/public/js/watchlist.js', '/public/js/ajax-form.js', '/public/js/shortlist-note.js', '/public/js/app.js'];
 
 router.use('/account', requireAuth);
 router.use('/watchlist', requireAuth);
@@ -257,7 +257,12 @@ router.delete('/shortlists/:id/items/:buildingId', async (req, res) => {
 router.post('/shortlists/:id/items/:buildingId/note', async (req, res) => {
   try {
     const cookie = req.session.backendCookie;
-    await api.shortlists.updateNote(req.params.id, req.params.buildingId, req.body.note || '', cookie);
+    await api.shortlists.updateNote(
+      req.params.id,
+      req.params.buildingId,
+      req.body.privateNote || req.body.note || '',
+      cookie
+    );
   } catch { /* ignore */ }
   return res.redirect(`/shortlists/${req.params.id}`);
 });

--- a/views/partials/note-form.handlebars
+++ b/views/partials/note-form.handlebars
@@ -1,11 +1,41 @@
-<form class="note-form" method="POST" action="/shortlists/{{shortlistId}}/items/{{itemId}}/note">
-  <label for="note-{{itemId}}" class="form-field label">{{t "noteForm.label"}}</label>
-  <textarea
-    id="note-{{itemId}}"
-    name="note"
-    aria-describedby="note-hint-{{itemId}}"
-    placeholder="{{t "noteForm.placeholder"}}"
-  >{{note}}</textarea>
-  <p class="form-hint" id="note-hint-{{itemId}}">{{t "noteForm.hint"}}</p>
-  <button class="button button-primary" type="submit">{{t "noteForm.save"}}</button>
+<form
+  class="note-form"
+  method="POST"
+  action="/shortlists/{{shortlistId}}/items/{{itemId}}/note"
+  data-note-form
+  data-note-max-length="1000"
+  data-loading-text="{{t "noteForm.saving"}}"
+  data-note-saved-message="{{t "noteForm.saved"}}"
+  data-note-error-message="{{t "noteForm.error"}}"
+  data-note-too-long-message="{{t "noteForm.tooLong"}}"
+>
+  <div class="note-form__header">
+    <label for="note-{{itemId}}" class="form-field label">{{t "noteForm.label"}}</label>
+    <span class="note-form__status" data-ajax-success role="status" aria-live="polite" hidden></span>
+  </div>
+
+  <div class="note-form__view" data-note-view>
+    <p class="note-form__preview" data-note-preview data-empty-text="{{t "noteForm.empty"}}">{{#if note}}{{note}}{{else}}{{t "noteForm.empty"}}{{/if}}</p>
+    <button class="button button-ghost" type="button" data-note-edit>{{t "noteForm.edit"}}</button>
+  </div>
+
+  <div class="note-form__editor" data-note-editor hidden>
+    <textarea
+      id="note-{{itemId}}"
+      name="privateNote"
+      aria-describedby="note-hint-{{itemId}} note-error-{{itemId}}"
+      maxlength="1000"
+      placeholder="{{t "noteForm.placeholder"}}"
+      data-note-input
+    >{{note}}</textarea>
+    <div class="note-form__meta">
+      <p class="form-hint" id="note-hint-{{itemId}}">{{t "noteForm.hint"}}</p>
+      <span class="note-form__counter" data-note-counter aria-live="polite"></span>
+    </div>
+    <p class="form-error" id="note-error-{{itemId}}" data-ajax-error data-field-error="privateNote" role="alert" hidden></p>
+    <div class="note-form__actions">
+      <button class="button button-ghost" type="button" data-note-cancel>{{t "noteForm.cancel"}}</button>
+      <button class="button button-primary" type="submit">{{t "noteForm.save"}}</button>
+    </div>
+  </div>
 </form>


### PR DESCRIPTION
## Summary

Implemented front-end issue #26: Complete shortlist note editing functionality.

## What Changed

- Added inline view/edit mode for shortlist private notes.
- Reworked `shortlist-note.js` to support edit, cancel, AJAX save, success feedback, and client-side note length validation.
- Reused the shared AJAX form helper for note submissions.
- Added API-side validation for note payloads with clear `fieldErrors.privateNote` responses.
- Added localized note editing labels and messages.

## Behavior Impact

Users can now edit shortlist notes inline without a full page reload. Invalid notes over 1000 characters are blocked before save and return a clear API validation error if submitted directly.

## Files Changed

- `locales/en.js`
- `locales/zh-CN.js`
- `public/css/main.css`
- `public/js/shortlist-note.js`
- `routes/api.js`
- `routes/user.js`
- `views/partials/note-form.handlebars`

## Testing

- Passed `node --check app.js`
- Passed `node --check routes/api.js`
- Passed `node --check routes/user.js`
- Passed `node --check public/js/shortlist-note.js`
- Passed `node --check public/js/ajax-form.js`
- Passed `node --check locales/en.js`
- Passed `node --check locales/zh-CN.js`
- Passed `git diff --check`
- Started a local mock backend and front-end server.
- Verified shortlist detail renders inline note editing structure and required scripts.
- Verified valid note AJAX save returns updated note data.
- Verified notes over 1000 characters return `400` with `fieldErrors.privateNote`.
- Verified refreshed shortlist detail shows the updated note.
- Stopped local test servers.

## Notes

This PR only covers front-end issue #26. It does not include unrelated authentication, CSRF, API client, or response adapter work.
